### PR TITLE
Pin specific git commit of `marvinpinto/action-automatic-release` to …

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,13 +17,13 @@ jobs:
         with:
           java-version: 11
       - name: Cache SonarCloud packages
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/tagged_release.yaml
+++ b/.github/workflows/tagged_release.yaml
@@ -32,7 +32,7 @@ jobs:
       run: shasum -a 256 ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/target/ch-covidcertificate-backend-verifier-ws.jar > ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/target/ch-covidcertificate-backend-verifier-ws.jar.sha256
       shell: bash
     - name: "Create new release"
-      uses: "marvinpinto/action-automatic-releases@latest"
+      uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         prerelease: false


### PR DESCRIPTION
This pull request pins a specific commit of the third-party action to reduce risk of supply chain attacks. It also bumps actions/cache v1 to v2