### PR TITLE
client sets if-none-match header, not etag

### DIFF
--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/KeyController.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/KeyController.java
@@ -26,10 +26,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.context.request.WebRequest;
 
 @Controller
 @RequestMapping("trust/v1/keys")
@@ -97,17 +97,16 @@ public class KeyController {
     @CrossOrigin(origins = {"https://editor.swagger.io"})
     @GetMapping(value = "list")
     public @ResponseBody ResponseEntity<ActiveCertsResponse> getActiveSignerCertKeyIds(
-            @RequestHeader(value = HttpHeaders.ETAG, required = false) String etag) {
+            WebRequest request) {
         List<String> activeKeyIds = verifierDataService.findActiveDscKeyIds();
 
         // check etag
         String currentEtag = String.valueOf(EtagUtil.getUnsortedListHashcode(activeKeyIds));
-        if (currentEtag.equals(etag)) {
+        if (request.checkNotModified(currentEtag)) {
             return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build();
         }
 
         return ResponseEntity.ok()
-                .header(HttpHeaders.ETAG, currentEtag)
                 .cacheControl(CacheControl.maxAge(CacheUtil.KEYS_LIST_MAX_AGE))
                 .body(new ActiveCertsResponse(activeKeyIds));
     }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/ValueSetsController.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/ValueSetsController.java
@@ -23,7 +23,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import org.apache.http.HttpHeaders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ClassPathResource;
@@ -32,9 +31,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.context.request.WebRequest;
 
 @Controller
 @RequestMapping("trust/v1")
@@ -97,13 +96,11 @@ public class ValueSetsController {
             responses = {"200 => value sets", "304 => no changes since last request"},
             responseHeaders = {"ETag:etag to set for next request:string"})
     @GetMapping(value = "/metadata")
-    public @ResponseBody ResponseEntity<ValueSets> getVerificationRules(
-            @RequestHeader(value = HttpHeaders.ETAG, required = false) String etag) {
-        if (valueSetsEtag.equals(etag)) {
+    public @ResponseBody ResponseEntity<ValueSets> getValueSets(WebRequest request) {
+        if (request.checkNotModified(valueSetsEtag)) {
             return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build();
         }
         return ResponseEntity.ok()
-                .header(HttpHeaders.ETAG, valueSetsEtag)
                 .cacheControl(CacheControl.maxAge(CacheUtil.VALUE_SETS_MAX_AGE))
                 .body(valueSets);
     }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/VerificationRulesController.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/VerificationRulesController.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Map;
-import org.apache.http.HttpHeaders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ClassPathResource;
@@ -27,9 +26,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.context.request.WebRequest;
 
 @Controller
 @RequestMapping("trust/v1")
@@ -55,13 +54,11 @@ public class VerificationRulesController {
             },
             responseHeaders = {"ETag:etag to set for next request:string"})
     @GetMapping(value = "/verificationRules")
-    public @ResponseBody ResponseEntity<Map> getVerificationRules(
-            @RequestHeader(value = HttpHeaders.ETAG, required = false) String etag) {
-        if (verificationRulesEtag.equals(etag)) {
+    public @ResponseBody ResponseEntity<Map> getVerificationRules(WebRequest request) {
+        if (request.checkNotModified(verificationRulesEtag)) {
             return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build();
         }
         return ResponseEntity.ok()
-                .header(HttpHeaders.ETAG, verificationRulesEtag)
                 .cacheControl(CacheControl.maxAge(CacheUtil.VERIFICATION_RULES_MAX_AGE))
                 .body(verificationRules);
     }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/RevocationListControllerTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/RevocationListControllerTest.java
@@ -85,8 +85,7 @@ public abstract class RevocationListControllerTest extends BaseControllerTest {
 
     @Test
     public void notModifiedTest() throws Exception {
-        String expectedEtag =
-                String.valueOf(EtagUtil.getUnsortedListHashcode(List.of(REVOKED_CERT)));
+        String expectedEtag = "\"" + EtagUtil.getUnsortedListHashcode(List.of(REVOKED_CERT)) + "\"";
 
         // get current etag
         setupExternalRevocationListMock(2);
@@ -94,20 +93,20 @@ public abstract class RevocationListControllerTest extends BaseControllerTest {
                 mockMvc.perform(
                                 get(revocationListUrl)
                                         .accept(acceptMediaType)
-                                        .header(HttpHeaders.ETAG, "random"))
+                                        .header(HttpHeaders.IF_NONE_MATCH, "random"))
                         .andExpect(status().is2xxSuccessful())
                         .andReturn()
                         .getResponse();
 
         // verify etag
-        String etag = response.getHeader(HttpHeaders.ETAG).replace("\"", "");
+        String etag = response.getHeader(HttpHeaders.ETAG);
         assertEquals(expectedEtag, etag);
 
         // test not modified
         mockMvc.perform(
                         get(revocationListUrl)
                                 .accept(acceptMediaType)
-                                .header(HttpHeaders.ETAG, etag))
+                                .header(HttpHeaders.IF_NONE_MATCH, etag))
                 .andExpect(status().isNotModified())
                 .andReturn()
                 .getResponse();

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/ValueSetsControllerTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/ValueSetsControllerTest.java
@@ -104,25 +104,30 @@ public abstract class ValueSetsControllerTest extends BaseControllerTest {
                         .map(p -> "classpath:" + p)
                         .collect(Collectors.toList());
         String expectedEtag =
-                EtagUtil.getSha1HashForFiles(
-                        pathsToValueSets.toArray(new String[pathsToValueSets.size()]));
+                "\""
+                        + EtagUtil.getSha1HashForFiles(
+                                pathsToValueSets.toArray(new String[pathsToValueSets.size()]))
+                        + "\"";
 
         // get current etag
         MockHttpServletResponse response =
                 mockMvc.perform(
                                 get(valueSetsUrl)
                                         .accept(acceptMediaType)
-                                        .header(HttpHeaders.ETAG, "random"))
+                                        .header(HttpHeaders.IF_NONE_MATCH, "random"))
                         .andExpect(status().is2xxSuccessful())
                         .andReturn()
                         .getResponse();
 
         // verify etag
-        String etag = response.getHeader(HttpHeaders.ETAG).replace("\"", "");
+        String etag = response.getHeader(HttpHeaders.ETAG);
         assertEquals(expectedEtag, etag);
 
         // test not modified
-        mockMvc.perform(get(valueSetsUrl).accept(acceptMediaType).header(HttpHeaders.ETAG, etag))
+        mockMvc.perform(
+                        get(valueSetsUrl)
+                                .accept(acceptMediaType)
+                                .header(HttpHeaders.IF_NONE_MATCH, etag))
                 .andExpect(status().isNotModified())
                 .andReturn()
                 .getResponse();

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/VerificationRulesControllerTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/VerificationRulesControllerTest.java
@@ -49,27 +49,28 @@ public abstract class VerificationRulesControllerTest extends BaseControllerTest
 
     @Test
     public void notModifiedTest() throws Exception {
-        String expectedEtag = EtagUtil.getSha1HashForFiles(PATH_TO_VERIFICATION_RULES);
+        String expectedEtag =
+                "\"" + EtagUtil.getSha1HashForFiles(PATH_TO_VERIFICATION_RULES) + "\"";
 
         // get current etag
         MockHttpServletResponse response =
                 mockMvc.perform(
                                 get(verificationRulesUrl)
                                         .accept(acceptMediaType)
-                                        .header(HttpHeaders.ETAG, "random"))
+                                        .header(HttpHeaders.IF_NONE_MATCH, "random"))
                         .andExpect(status().is2xxSuccessful())
                         .andReturn()
                         .getResponse();
 
         // verify etag
-        String etag = response.getHeader(HttpHeaders.ETAG).replace("\"", "");
+        String etag = response.getHeader(HttpHeaders.ETAG);
         assertEquals(expectedEtag, etag);
 
         // test not modified
         mockMvc.perform(
                         get(verificationRulesUrl)
                                 .accept(acceptMediaType)
-                                .header(HttpHeaders.ETAG, etag))
+                                .header(HttpHeaders.IF_NONE_MATCH, etag))
                 .andExpect(status().isNotModified())
                 .andReturn()
                 .getResponse();

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/resources/http/verifier-ws.http
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/resources/http/verifier-ws.http
@@ -10,23 +10,23 @@ Authorization: Bearer {{apiKey}}
 ### get active cert key ids
 GET {{baseUrl}}/v1/keys/list
 Accept: application/json
-ETag: -720957702
+If-None-Match: "-720957702"
 Authorization: Bearer {{apiKey}}
 
 ### get revocation list
 GET {{baseUrl}}/v1/revocationList
 Accept: application/json
-ETag: -103666649
+If-None-Match: "1089905096"
 Authorization: Bearer {{apiKey}}
 
 ### get verification rules
 GET {{baseUrl}}/v1/verificationRules
 Accept: application/json
-ETag: f4915f1428328eb6c239693fc8e6541f68a3f72e
+If-None-Match: "011ec25ca7a4d0c95fe8fd7c33cdeff3654d7bf9"
 Authorization: Bearer {{apiKey}}
 
 ### get value sets
 GET {{baseUrl}}/v1/metadata
 Accept: application/json
-ETag: f4915f1428328eb6c239693fc8e6541f68a3f72e
+If-None-Match: "e8832aef5f37843e52a5acb78c522fa36576a62e"
 Authorization: Bearer {{apiKey}}


### PR DESCRIPTION
this pull request fixes the request header required for caching with etag.