### PR TITLE
Added sql query parametrization

### DIFF
--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/impl/JdbcVerifierDataServiceImpl.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/impl/JdbcVerifierDataServiceImpl.java
@@ -158,20 +158,10 @@ public class JdbcVerifierDataServiceImpl implements VerifierDataService {
                         + " alg,"
                         + " crv,"
                         + " x,"
-                        + " y, ";
-        switch (certFormat) {
-            case IOS:
-                sql += "subject_public_key_info";
-                break;
-            case ANDROID:
-                sql += "n, e";
-                break;
-            default:
-                throw new RuntimeException("unexpected cert format received: " + certFormat);
-        }
-
-        sql +=
-                " from t_document_signer_certificate"
+                        + " y, "
+                        + "subject_public_key_info, "
+                        + "n, e"
+                        + " from t_document_signer_certificate"
                         + " where pk_dsc_id > :pk_dsc_id"
                         + " order by pk_dsc_id asc"
                         + " limit :max_dsc_batch_count";


### PR DESCRIPTION
A security review revealed that the `findDscs` method in the `JdbcVerifierDataServiceImpl` class might in the future become vulnerable to SQL injection attacks. In order to mitigate this issue, it was recommended to use prepared SQL statements, which are injection-safe by design.