### PR TITLE
App token dataservice

### DIFF
--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/AppTokenDataService.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/AppTokenDataService.java
@@ -1,0 +1,15 @@
+package ch.admin.bag.covidcertificate.backend.verifier.data;
+
+import ch.admin.bag.covidcertificate.backend.verifier.model.AppToken;
+import java.util.List;
+
+/**
+ * Dataservice allowing the fetching of stored app tokens. Insertion and removal are done by hand.
+ */
+public interface AppTokenDataService {
+
+    /**
+     * Fetches all app tokens contained in the database
+     */
+    public List<AppToken> getAppTokens();
+}

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/impl/JdbcAppTokenDataServiceImpl.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/impl/JdbcAppTokenDataServiceImpl.java
@@ -1,0 +1,25 @@
+package ch.admin.bag.covidcertificate.backend.verifier.data.impl;
+
+import ch.admin.bag.covidcertificate.backend.verifier.data.AppTokenDataService;
+import ch.admin.bag.covidcertificate.backend.verifier.data.mapper.AppTokenRowMapper;
+import ch.admin.bag.covidcertificate.backend.verifier.model.AppToken;
+import java.util.List;
+import javax.sql.DataSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+public class JdbcAppTokenDataServiceImpl implements AppTokenDataService {
+
+    private final NamedParameterJdbcTemplate jt;
+
+    public JdbcAppTokenDataServiceImpl(DataSource dataSource) {
+        this.jt = new NamedParameterJdbcTemplate(dataSource);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AppToken> getAppTokens() {
+        final var sql = "select * from t_app_tokens";
+        return jt.query(sql, new AppTokenRowMapper());
+    }
+}

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/mapper/AppTokenRowMapper.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/mapper/AppTokenRowMapper.java
@@ -1,0 +1,17 @@
+package ch.admin.bag.covidcertificate.backend.verifier.data.mapper;
+
+import ch.admin.bag.covidcertificate.backend.verifier.model.AppToken;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.springframework.jdbc.core.RowMapper;
+
+public class AppTokenRowMapper implements RowMapper<AppToken> {
+
+    @Override
+    public AppToken mapRow(ResultSet resultSet, int i) throws SQLException {
+        var appToken = new AppToken();
+        appToken.setApiKey(resultSet.getString("api_key"));
+        appToken.setDescription(resultSet.getString("description"));
+        return appToken;
+    }
+}

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/resources/db/migration/pgsql/V0_3__api_tokens.sql
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/resources/db/migration/pgsql/V0_3__api_tokens.sql
@@ -1,0 +1,12 @@
+/*
+ * Created by Ubique Innovation AG
+ * https://www.ubique.ch
+ * Copyright (c) 2021. All rights reserved.
+ */
+
+CREATE TABLE t_app_tokens
+(
+    api_key     character varying(50)  NOT NULL,
+    description character varying(100) NOT NULL,
+    CONSTRAINT pk_t_app_tokens PRIMARY KEY (api_key)
+);

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/resources/db/migration/pgsql_cluster/V0_3__api_tokens.sql
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/resources/db/migration/pgsql_cluster/V0_3__api_tokens.sql
@@ -1,0 +1,12 @@
+/*
+ * Created by Ubique Innovation AG
+ * https://www.ubique.ch
+ * Copyright (c) 2021. All rights reserved.
+ */
+
+CREATE TABLE t_app_tokens
+(
+    api_key     character varying(50)  NOT NULL,
+    description character varying(100) NOT NULL,
+    CONSTRAINT pk_t_app_tokens PRIMARY KEY (api_key)
+);

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/data/AppTokenDataServiceTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/data/AppTokenDataServiceTest.java
@@ -1,0 +1,30 @@
+package ch.admin.bag.covidcertificate.backend.verifier.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+
+class AppTokenDataServiceTest extends BaseDataServiceTest {
+
+    @Autowired AppTokenDataService appTokenDataService;
+    @Autowired DataSource dataSource;
+
+    @Test
+    void getAppTokensTest() {
+        var appTokens = appTokenDataService.getAppTokens();
+        assertTrue(appTokens.isEmpty());
+        final var insert = new SimpleJdbcInsert(dataSource).withTableName("t_app_tokens");
+        final var params = new MapSqlParameterSource();
+        params.addValue("api_key", "4d1d5663-b4ef-46a5-85b6-3d1d376429da");
+        params.addValue("description", "local");
+        insert.execute(params);
+        appTokens = appTokenDataService.getAppTokens();
+        assertEquals(1, appTokens.size());
+    }
+}

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/data/config/TestConfig.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/data/config/TestConfig.java
@@ -10,7 +10,9 @@
 
 package ch.admin.bag.covidcertificate.backend.verifier.data.config;
 
+import ch.admin.bag.covidcertificate.backend.verifier.data.AppTokenDataService;
 import ch.admin.bag.covidcertificate.backend.verifier.data.VerifierDataService;
+import ch.admin.bag.covidcertificate.backend.verifier.data.impl.JdbcAppTokenDataServiceImpl;
 import ch.admin.bag.covidcertificate.backend.verifier.data.impl.JdbcVerifierDataServiceImpl;
 import javax.sql.DataSource;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -24,5 +26,10 @@ public class TestConfig {
     @Bean
     public VerifierDataService verifierDataService(DataSource dataSource) {
         return new JdbcVerifierDataServiceImpl(dataSource);
+    }
+
+    @Bean
+    public AppTokenDataService appTokenDataService(DataSource dataSource) {
+        return new JdbcAppTokenDataServiceImpl(dataSource);
     }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-model/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/model/AppToken.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-model/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/model/AppToken.java
@@ -1,0 +1,23 @@
+package ch.admin.bag.covidcertificate.backend.verifier.model;
+
+public class AppToken {
+
+    private String apiKey;
+    private String description;
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/WSSchedulingConfig.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/WSSchedulingConfig.java
@@ -3,7 +3,9 @@ package ch.admin.bag.covidcertificate.backend.verifier.ws.config;
 import ch.admin.bag.covidcertificate.backend.verifier.data.AppTokenDataService;
 import ch.admin.bag.covidcertificate.backend.verifier.model.AppToken;
 import ch.admin.bag.covidcertificate.backend.verifier.ws.config.model.ApiKeyConfig;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -25,5 +27,10 @@ public class WSSchedulingConfig {
     @Scheduled(cron = "${ws.authentication.cron:0 0/5 0 ? * *}")
     public void updateAppTokens() {
         final var appTokens = appTokenDataService.getAppTokens();
+        final Map<String, String> apiKeys = new HashMap<>();
+        for (var token: appTokens) {
+            apiKeys.put(token.getDescription(), token.getApiKey());
+        }
+        apiKeyConfig.setApiKeys(apiKeys);
     }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/WSSchedulingConfig.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/WSSchedulingConfig.java
@@ -1,0 +1,29 @@
+package ch.admin.bag.covidcertificate.backend.verifier.ws.config;
+
+import ch.admin.bag.covidcertificate.backend.verifier.data.AppTokenDataService;
+import ch.admin.bag.covidcertificate.backend.verifier.model.AppToken;
+import ch.admin.bag.covidcertificate.backend.verifier.ws.config.model.ApiKeyConfig;
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Configuration
+@EnableScheduling
+public class WSSchedulingConfig {
+
+    private final ApiKeyConfig apiKeyConfig;
+    private final AppTokenDataService appTokenDataService;
+
+    public WSSchedulingConfig(
+        ApiKeyConfig apiKeyConfig,
+        AppTokenDataService appTokenDataService) {
+        this.apiKeyConfig = apiKeyConfig;
+        this.appTokenDataService = appTokenDataService;
+    }
+
+    @Scheduled(cron = "${ws.authentication.cron:0 0/5 0 ? * *}")
+    public void updateAppTokens() {
+        final var appTokens = appTokenDataService.getAppTokens();
+    }
+}

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/WSSchedulingConfig.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/WSSchedulingConfig.java
@@ -27,7 +27,6 @@ public class WSSchedulingConfig {
 
     // Call method every 5 minutes starting at 0am, of every day
     @Scheduled(cron = "${ws.authentication.cron:0 0/5 0 ? * *}")
-    @Scheduled(fixedRate = 30000, initialDelay = 10000)
     public void updateAppTokens() {
         logger.info("Updating app tokens");
         final var appTokens = appTokenDataService.getAppTokens();

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/WSSchedulingConfig.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/WSSchedulingConfig.java
@@ -1,10 +1,8 @@
 package ch.admin.bag.covidcertificate.backend.verifier.ws.config;
 
 import ch.admin.bag.covidcertificate.backend.verifier.data.AppTokenDataService;
-import ch.admin.bag.covidcertificate.backend.verifier.model.AppToken;
 import ch.admin.bag.covidcertificate.backend.verifier.ws.config.model.ApiKeyConfig;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -17,18 +15,17 @@ public class WSSchedulingConfig {
     private final ApiKeyConfig apiKeyConfig;
     private final AppTokenDataService appTokenDataService;
 
-    public WSSchedulingConfig(
-        ApiKeyConfig apiKeyConfig,
-        AppTokenDataService appTokenDataService) {
+    public WSSchedulingConfig(ApiKeyConfig apiKeyConfig, AppTokenDataService appTokenDataService) {
         this.apiKeyConfig = apiKeyConfig;
         this.appTokenDataService = appTokenDataService;
     }
 
+    // Call method every 5 minutes starting at 0am, of every day
     @Scheduled(cron = "${ws.authentication.cron:0 0/5 0 ? * *}")
     public void updateAppTokens() {
         final var appTokens = appTokenDataService.getAppTokens();
         final Map<String, String> apiKeys = new HashMap<>();
-        for (var token: appTokens) {
+        for (var token : appTokens) {
             apiKeys.put(token.getDescription(), token.getApiKey());
         }
         apiKeyConfig.setApiKeys(apiKeys);

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/WSSchedulingConfig.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/WSSchedulingConfig.java
@@ -2,7 +2,6 @@ package ch.admin.bag.covidcertificate.backend.verifier.ws.config;
 
 import ch.admin.bag.covidcertificate.backend.verifier.data.AppTokenDataService;
 import ch.admin.bag.covidcertificate.backend.verifier.ws.config.model.ApiKeyConfig;
-import ch.admin.bag.covidcertificate.backend.verifier.ws.controller.RevocationListController;
 import java.util.HashMap;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -15,10 +14,9 @@ import org.springframework.scheduling.annotation.Scheduled;
 @EnableScheduling
 public class WSSchedulingConfig {
 
+    private static final Logger logger = LoggerFactory.getLogger(WSSchedulingConfig.class);
     private final ApiKeyConfig apiKeyConfig;
     private final AppTokenDataService appTokenDataService;
-
-    private static final Logger logger = LoggerFactory.getLogger(WSSchedulingConfig.class);
 
     public WSSchedulingConfig(ApiKeyConfig apiKeyConfig, AppTokenDataService appTokenDataService) {
         this.apiKeyConfig = apiKeyConfig;

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/WSSchedulingConfig.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/WSSchedulingConfig.java
@@ -2,8 +2,11 @@ package ch.admin.bag.covidcertificate.backend.verifier.ws.config;
 
 import ch.admin.bag.covidcertificate.backend.verifier.data.AppTokenDataService;
 import ch.admin.bag.covidcertificate.backend.verifier.ws.config.model.ApiKeyConfig;
+import ch.admin.bag.covidcertificate.backend.verifier.ws.controller.RevocationListController;
 import java.util.HashMap;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -15,6 +18,8 @@ public class WSSchedulingConfig {
     private final ApiKeyConfig apiKeyConfig;
     private final AppTokenDataService appTokenDataService;
 
+    private static final Logger logger = LoggerFactory.getLogger(WSSchedulingConfig.class);
+
     public WSSchedulingConfig(ApiKeyConfig apiKeyConfig, AppTokenDataService appTokenDataService) {
         this.apiKeyConfig = apiKeyConfig;
         this.appTokenDataService = appTokenDataService;
@@ -22,7 +27,9 @@ public class WSSchedulingConfig {
 
     // Call method every 5 minutes starting at 0am, of every day
     @Scheduled(cron = "${ws.authentication.cron:0 0/5 0 ? * *}")
+    @Scheduled(fixedRate = 30000, initialDelay = 10000)
     public void updateAppTokens() {
+        logger.info("Updating app tokens");
         final var appTokens = appTokenDataService.getAppTokens();
         final Map<String, String> apiKeys = new HashMap<>();
         for (var token : appTokens) {

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/WsBaseConfig.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/WsBaseConfig.java
@@ -10,7 +10,9 @@
 
 package ch.admin.bag.covidcertificate.backend.verifier.ws.config;
 
+import ch.admin.bag.covidcertificate.backend.verifier.data.AppTokenDataService;
 import ch.admin.bag.covidcertificate.backend.verifier.data.VerifierDataService;
+import ch.admin.bag.covidcertificate.backend.verifier.data.impl.JdbcAppTokenDataServiceImpl;
 import ch.admin.bag.covidcertificate.backend.verifier.data.impl.JdbcVerifierDataServiceImpl;
 import ch.admin.bag.covidcertificate.backend.verifier.ws.controller.KeyController;
 import ch.admin.bag.covidcertificate.backend.verifier.ws.controller.RevocationListController;
@@ -126,6 +128,11 @@ public abstract class WsBaseConfig implements WebMvcConfigurer {
     @Bean
     public VerifierDataService verifierDataService(DataSource dataSource) {
         return new JdbcVerifierDataServiceImpl(dataSource);
+    }
+
+    @Bean
+    public AppTokenDataService appTokenDataService(DataSource dataSource) {
+        return new JdbcAppTokenDataServiceImpl(dataSource);
     }
 
     @Bean


### PR DESCRIPTION
To avoid hardcoding the API key that the client includes in its API requests, we store them in the database.
`AppTokenDataService` allows the fetching of stored app tokens. Insertion and removal are done by hand.
The `WSSchedulingConfig` includes a periodically scheduled cronjob that updates the accepted API tokens.