### PR TITLE
Release updated key list/updates only once per hour

### DIFF
--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/VerifierDataService.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/VerifierDataService.java
@@ -14,49 +14,53 @@ import ch.admin.bag.covidcertificate.backend.verifier.model.cert.CertFormat;
 import ch.admin.bag.covidcertificate.backend.verifier.model.cert.ClientCert;
 import ch.admin.bag.covidcertificate.backend.verifier.model.cert.db.DbCsca;
 import ch.admin.bag.covidcertificate.backend.verifier.model.cert.db.DbDsc;
+import java.util.Date;
 import java.util.List;
 
 public interface VerifierDataService {
 
-    /** inserts the given CSCAs into the db */
-    public void insertCSCAs(List<DbCsca> cscas);
+  /** inserts the given CSCAs into the db */
+  public void insertCSCAs(List<DbCsca> cscas);
 
-    /**
-     * removes all csas with key ids in the given list
-     *
-     * @param keyIds
-     * @return number of removed CSCAs
-     */
-    public int removeCSCAs(List<String> keyIds);
+  /**
+   * removes all csas with key ids in the given list
+   *
+   * @param keyIds
+   * @return number of removed CSCAs
+   */
+  public int removeCSCAs(List<String> keyIds);
 
-    /**
-     * finds all CSCAs of the given origin country
-     *
-     * @param origin abbreviation for country of origin (e.g. "CH")
-     * @return list of all CSCAs with the corresponding origin
-     */
-    public List<DbCsca> findCSCAs(String origin);
+  /**
+   * finds all CSCAs of the given origin country
+   *
+   * @param origin abbreviation for country of origin (e.g. "CH")
+   * @return list of all CSCAs with the corresponding origin
+   */
+  public List<DbCsca> findCSCAs(String origin);
 
-    /** returns a list of key ids of all active CSCAs */
-    public List<String> findActiveCSCAKeyIds();
+  /** returns a list of key ids of all active CSCAs */
+  public List<String> findActiveCSCAKeyIds();
 
-    /** inserts the given DSC into the db */
-    public void insertDSCs(List<DbDsc> dsc);
+  /** inserts the given DSC into the db */
+  public void insertDSCs(List<DbDsc> dsc);
 
-    /** removes all DSCs with key ids not in the given list */
-    public int removeDSCsNotIn(List<String> keyIdsToKeep);
+  /** removes all DSCs with key ids not in the given list */
+  public int removeDSCsNotIn(List<String> keyIdsToKeep);
 
-    /** removes all DSCs signed by a CSCA in the given list */
-    public int removeDSCsWithCSCAIn(List<String> cscaKidsToRemove);
+  /** removes all DSCs signed by a CSCA in the given list */
+  public int removeDSCsWithCSCAIn(List<String> cscaKidsToRemove);
 
-    /** returns the next batch of DSCs after since in the requested format */
-    public List<ClientCert> findDSCs(Long since, CertFormat certFormat);
+  /**
+   * returns the next batch of DSCs after `since` but before `importedBefore` in the requested
+   * format
+   */
+  public List<ClientCert> findDSCs(Long since, CertFormat certFormat, Date importedBefore);
 
-    /** returns a list of key ids of all active DSCs */
-    public List<String> findActiveDSCKeyIds();
+  /** returns a list of key ids of all active DSCs before a certain timestamp */
+  public List<String> findActiveDSCKeyIds(Date importedBefore);
 
-    /** returns the highest DSC pk id */
-    public long findMaxDSCPkId();
+  /** returns the highest DSC pk id */
+  public long findMaxDSCPkId();
 
-    public int getMaxDSCBatchCount();
+  public int getMaxDSCBatchCount();
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/VerifierDataService.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/VerifierDataService.java
@@ -19,48 +19,48 @@ import java.util.List;
 
 public interface VerifierDataService {
 
-  /** inserts the given CSCAs into the db */
-  public void insertCSCAs(List<DbCsca> cscas);
+    /** inserts the given CSCAs into the db */
+    public void insertCSCAs(List<DbCsca> cscas);
 
-  /**
-   * removes all csas with key ids in the given list
-   *
-   * @param keyIds
-   * @return number of removed CSCAs
-   */
-  public int removeCSCAs(List<String> keyIds);
+    /**
+     * removes all csas with key ids in the given list
+     *
+     * @param keyIds
+     * @return number of removed CSCAs
+     */
+    public int removeCSCAs(List<String> keyIds);
 
-  /**
-   * finds all CSCAs of the given origin country
-   *
-   * @param origin abbreviation for country of origin (e.g. "CH")
-   * @return list of all CSCAs with the corresponding origin
-   */
-  public List<DbCsca> findCSCAs(String origin);
+    /**
+     * finds all CSCAs of the given origin country
+     *
+     * @param origin abbreviation for country of origin (e.g. "CH")
+     * @return list of all CSCAs with the corresponding origin
+     */
+    public List<DbCsca> findCSCAs(String origin);
 
-  /** returns a list of key ids of all active CSCAs */
-  public List<String> findActiveCSCAKeyIds();
+    /** returns a list of key ids of all active CSCAs */
+    public List<String> findActiveCSCAKeyIds();
 
-  /** inserts the given DSC into the db */
-  public void insertDSCs(List<DbDsc> dsc);
+    /** inserts the given DSC into the db */
+    public void insertDSCs(List<DbDsc> dsc);
 
-  /** removes all DSCs with key ids not in the given list */
-  public int removeDSCsNotIn(List<String> keyIdsToKeep);
+    /** removes all DSCs with key ids not in the given list */
+    public int removeDSCsNotIn(List<String> keyIdsToKeep);
 
-  /** removes all DSCs signed by a CSCA in the given list */
-  public int removeDSCsWithCSCAIn(List<String> cscaKidsToRemove);
+    /** removes all DSCs signed by a CSCA in the given list */
+    public int removeDSCsWithCSCAIn(List<String> cscaKidsToRemove);
 
-  /**
-   * returns the next batch of DSCs after `since` but before `importedBefore` in the requested
-   * format
-   */
-  public List<ClientCert> findDSCs(Long since, CertFormat certFormat, Date importedBefore);
+    /**
+     * returns the next batch of DSCs after `since` but before `importedBefore` in the requested
+     * format
+     */
+    public List<ClientCert> findDSCs(Long since, CertFormat certFormat, Date importedBefore);
 
-  /** returns a list of key ids of all active DSCs before a certain timestamp */
-  public List<String> findActiveDSCKeyIds(Date importedBefore);
+    /** returns a list of key ids of all active DSCs before a certain timestamp */
+    public List<String> findActiveDSCKeyIds(Date importedBefore);
 
-  /** returns the highest DSC pk id */
-  public long findMaxDSCPkId();
+    /** returns the highest DSC pk id */
+    public long findMaxDSCPkId();
 
-  public int getMaxDSCBatchCount();
+    public int getMaxDSCBatchCount();
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/impl/JdbcVerifierDataServiceImpl.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/impl/JdbcVerifierDataServiceImpl.java
@@ -33,199 +33,201 @@ import org.springframework.transaction.annotation.Transactional;
 
 public class JdbcVerifierDataServiceImpl implements VerifierDataService {
 
-  private static final Logger logger = LoggerFactory.getLogger(JdbcVerifierDataServiceImpl.class);
+    private static final Logger logger = LoggerFactory.getLogger(JdbcVerifierDataServiceImpl.class);
 
-  private static final int MAX_DSC_BATCH_COUNT = 1000;
-  private final NamedParameterJdbcTemplate jt;
-  private final SimpleJdbcInsert cscaInsert;
-  private final SimpleJdbcInsert dscInsert;
+    private static final int MAX_DSC_BATCH_COUNT = 1000;
+    private final NamedParameterJdbcTemplate jt;
+    private final SimpleJdbcInsert cscaInsert;
+    private final SimpleJdbcInsert dscInsert;
 
-  public JdbcVerifierDataServiceImpl(DataSource dataSource) {
-    this.jt = new NamedParameterJdbcTemplate(dataSource);
-    this.cscaInsert =
-        new SimpleJdbcInsert(dataSource)
-            .withTableName("t_country_specific_certificate_authority")
-            .usingGeneratedKeyColumns("pk_csca_id", "imported_at");
-    this.dscInsert =
-        new SimpleJdbcInsert(dataSource)
-            .withTableName("t_document_signer_certificate")
-            .usingGeneratedKeyColumns("pk_dsc_id", "imported_at");
-  }
-
-  @Override
-  @Transactional
-  public void insertCSCAs(List<DbCsca> cscas) {
-    logger.debug(
-        "Inserting CSCA certificates with kid's: {}",
-        cscas.stream().map(DbCsca::getKeyId).collect(Collectors.toList()));
-    List<SqlParameterSource> batchParams = new ArrayList<>();
-    if (!cscas.isEmpty()) {
-      for (DbCsca dbCsca : cscas) {
-        batchParams.add(getCSCAParams(dbCsca));
-      }
-      cscaInsert.executeBatch(batchParams.toArray(new SqlParameterSource[batchParams.size()]));
+    public JdbcVerifierDataServiceImpl(DataSource dataSource) {
+        this.jt = new NamedParameterJdbcTemplate(dataSource);
+        this.cscaInsert =
+                new SimpleJdbcInsert(dataSource)
+                        .withTableName("t_country_specific_certificate_authority")
+                        .usingGeneratedKeyColumns("pk_csca_id", "imported_at");
+        this.dscInsert =
+                new SimpleJdbcInsert(dataSource)
+                        .withTableName("t_document_signer_certificate")
+                        .usingGeneratedKeyColumns("pk_dsc_id", "imported_at");
     }
-  }
 
-  @Override
-  @Transactional
-  public int removeCSCAs(List<String> keyIds) {
-    if (!keyIds.isEmpty()) {
-      var sql = "delete from t_country_specific_certificate_authority";
-      final var params = new MapSqlParameterSource();
-      sql += " where key_id in (:kids)";
-      params.addValue("kids", keyIds);
-      return jt.update(sql, params);
-    } else {
-      return 0;
+    @Override
+    @Transactional
+    public void insertCSCAs(List<DbCsca> cscas) {
+        logger.debug(
+                "Inserting CSCA certificates with kid's: {}",
+                cscas.stream().map(DbCsca::getKeyId).collect(Collectors.toList()));
+        List<SqlParameterSource> batchParams = new ArrayList<>();
+        if (!cscas.isEmpty()) {
+            for (DbCsca dbCsca : cscas) {
+                batchParams.add(getCSCAParams(dbCsca));
+            }
+            cscaInsert.executeBatch(
+                    batchParams.toArray(new SqlParameterSource[batchParams.size()]));
+        }
     }
-  }
 
-  @Override
-  @Transactional(readOnly = true)
-  public List<DbCsca> findCSCAs(String origin) {
-    final var sql = "select * from t_country_specific_certificate_authority where origin = :origin";
-    final var params = new MapSqlParameterSource();
-    params.addValue("origin", origin);
-    return jt.query(sql, params, new CSCARowMapper());
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public List<String> findActiveCSCAKeyIds() {
-    final var sql = "select key_id from t_country_specific_certificate_authority";
-    return jt.queryForList(sql, new MapSqlParameterSource(), String.class);
-  }
-
-  @Override
-  @Transactional
-  public void insertDSCs(List<DbDsc> dsc) {
-    List<SqlParameterSource> batchParams = new ArrayList<>();
-    if (!dsc.isEmpty()) {
-      for (DbDsc dbDsc : dsc) {
-        batchParams.add(getDSCParams(dbDsc));
-      }
-      dscInsert.executeBatch(batchParams.toArray(new SqlParameterSource[batchParams.size()]));
+    @Override
+    @Transactional
+    public int removeCSCAs(List<String> keyIds) {
+        if (!keyIds.isEmpty()) {
+            var sql = "delete from t_country_specific_certificate_authority";
+            final var params = new MapSqlParameterSource();
+            sql += " where key_id in (:kids)";
+            params.addValue("kids", keyIds);
+            return jt.update(sql, params);
+        } else {
+            return 0;
+        }
     }
-  }
 
-  @Override
-  @Transactional
-  public int removeDSCsNotIn(List<String> keyIdsToKeep) {
-    var sql = "delete from t_document_signer_certificate";
-    final var params = new MapSqlParameterSource();
-    if (!keyIdsToKeep.isEmpty()) {
-      sql += " where key_id not in (:kids)";
-      params.addValue("kids", keyIdsToKeep);
+    @Override
+    @Transactional(readOnly = true)
+    public List<DbCsca> findCSCAs(String origin) {
+        final var sql =
+                "select * from t_country_specific_certificate_authority where origin = :origin";
+        final var params = new MapSqlParameterSource();
+        params.addValue("origin", origin);
+        return jt.query(sql, params, new CSCARowMapper());
     }
-    return jt.update(sql, params);
-  }
 
-  @Override
-  @Transactional
-  public int removeDSCsWithCSCAIn(List<String> cscaKidsToRemove) {
-    if (!cscaKidsToRemove.isEmpty()) {
-      var sql = "delete from t_document_signer_certificate where fk_csca_id in (:fk_csca_id)";
-      final var params = new MapSqlParameterSource();
-      params.addValue("fk_csca_id", findCscaPksForKids(cscaKidsToRemove));
-      return jt.update(sql, params);
-    } else {
-      return 0;
+    @Override
+    @Transactional(readOnly = true)
+    public List<String> findActiveCSCAKeyIds() {
+        final var sql = "select key_id from t_country_specific_certificate_authority";
+        return jt.queryForList(sql, new MapSqlParameterSource(), String.class);
     }
-  }
 
-  private List<Long> findCscaPksForKids(List<String> cscaKids) {
-    if (!cscaKids.isEmpty()) {
-      final var sql =
-          "select pk_csca_id from t_country_specific_certificate_authority where key_id in (:kids)";
-      final var params = new MapSqlParameterSource();
-      params.addValue("kids", cscaKids);
-      return jt.queryForList(sql, params, Long.class);
-    } else {
-      return new ArrayList<>();
+    @Override
+    @Transactional
+    public void insertDSCs(List<DbDsc> dsc) {
+        List<SqlParameterSource> batchParams = new ArrayList<>();
+        if (!dsc.isEmpty()) {
+            for (DbDsc dbDsc : dsc) {
+                batchParams.add(getDSCParams(dbDsc));
+            }
+            dscInsert.executeBatch(batchParams.toArray(new SqlParameterSource[batchParams.size()]));
+        }
     }
-  }
 
-  @Override
-  @Transactional(readOnly = true)
-  public List<ClientCert> findDSCs(Long since, CertFormat certFormat, Date importedBefore) {
-    String sql =
-        "select pk_dsc_id,"
-            + " key_id,"
-            + " origin,"
-            + " use,"
-            + " alg,"
-            + " crv,"
-            + " x,"
-            + " y, "
-            + "subject_public_key_info, "
-            + "n, e"
-            + " from t_document_signer_certificate"
-            + " where pk_dsc_id > :pk_dsc_id"
-            + " and imported_at < :before"
-            + " order by pk_dsc_id asc"
-            + " limit :max_dsc_batch_count";
-
-    var params = new MapSqlParameterSource();
-    params.addValue("pk_dsc_id", since);
-    params.addValue("max_dsc_batch_count", MAX_DSC_BATCH_COUNT);
-    params.addValue("before", importedBefore);
-
-    return jt.query(sql, params, new ClientCertRowMapper(certFormat));
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public List<String> findActiveDSCKeyIds(Date importedBefore) {
-    String sql =
-        "select key_id from t_document_signer_certificate where imported_at < :before order by pk_dsc_id";
-    MapSqlParameterSource params = new MapSqlParameterSource();
-    params.addValue("before", importedBefore);
-    return jt.queryForList(sql, params, String.class);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public long findMaxDSCPkId() {
-    try {
-      String sql =
-          "select pk_dsc_id from t_document_signer_certificate"
-              + " order by pk_dsc_id desc"
-              + " limit 1";
-      return jt.queryForObject(sql, new MapSqlParameterSource(), Long.class);
-    } catch (EmptyResultDataAccessException e) {
-      return 0L;
+    @Override
+    @Transactional
+    public int removeDSCsNotIn(List<String> keyIdsToKeep) {
+        var sql = "delete from t_document_signer_certificate";
+        final var params = new MapSqlParameterSource();
+        if (!keyIdsToKeep.isEmpty()) {
+            sql += " where key_id not in (:kids)";
+            params.addValue("kids", keyIdsToKeep);
+        }
+        return jt.update(sql, params);
     }
-  }
 
-  @Override
-  public int getMaxDSCBatchCount() {
-    return MAX_DSC_BATCH_COUNT;
-  }
+    @Override
+    @Transactional
+    public int removeDSCsWithCSCAIn(List<String> cscaKidsToRemove) {
+        if (!cscaKidsToRemove.isEmpty()) {
+            var sql = "delete from t_document_signer_certificate where fk_csca_id in (:fk_csca_id)";
+            final var params = new MapSqlParameterSource();
+            params.addValue("fk_csca_id", findCscaPksForKids(cscaKidsToRemove));
+            return jt.update(sql, params);
+        } else {
+            return 0;
+        }
+    }
 
-  private MapSqlParameterSource getCSCAParams(DbCsca dbCsca) {
-    var params = new MapSqlParameterSource();
-    params.addValue("key_id", dbCsca.getKeyId());
-    params.addValue("certificate_raw", dbCsca.getCertificateRaw());
-    params.addValue("origin", dbCsca.getOrigin());
-    params.addValue("subject_principal_name", dbCsca.getSubjectPrincipalName());
-    return params;
-  }
+    private List<Long> findCscaPksForKids(List<String> cscaKids) {
+        if (!cscaKids.isEmpty()) {
+            final var sql =
+                    "select pk_csca_id from t_country_specific_certificate_authority where key_id in (:kids)";
+            final var params = new MapSqlParameterSource();
+            params.addValue("kids", cscaKids);
+            return jt.queryForList(sql, params, Long.class);
+        } else {
+            return new ArrayList<>();
+        }
+    }
 
-  private MapSqlParameterSource getDSCParams(DbDsc dbDsc) {
-    var params = new MapSqlParameterSource();
-    params.addValue("key_id", dbDsc.getKeyId());
-    params.addValue("fk_csca_id", dbDsc.getFkCsca());
-    params.addValue("certificate_raw", dbDsc.getCertificateRaw());
-    params.addValue("origin", dbDsc.getOrigin());
-    params.addValue("use", dbDsc.getUse());
-    params.addValue("alg", dbDsc.getAlg().name());
-    params.addValue("n", dbDsc.getN());
-    params.addValue("e", dbDsc.getE());
-    params.addValue("subject_public_key_info", dbDsc.getSubjectPublicKeyInfo());
-    params.addValue("crv", dbDsc.getCrv());
-    params.addValue("x", dbDsc.getX());
-    params.addValue("y", dbDsc.getY());
-    return params;
-  }
+    @Override
+    @Transactional(readOnly = true)
+    public List<ClientCert> findDSCs(Long since, CertFormat certFormat, Date importedBefore) {
+        String sql =
+                "select pk_dsc_id,"
+                        + " key_id,"
+                        + " origin,"
+                        + " use,"
+                        + " alg,"
+                        + " crv,"
+                        + " x,"
+                        + " y, "
+                        + "subject_public_key_info, "
+                        + "n, e"
+                        + " from t_document_signer_certificate"
+                        + " where pk_dsc_id > :pk_dsc_id"
+                        + " and imported_at < :before"
+                        + " order by pk_dsc_id asc"
+                        + " limit :max_dsc_batch_count";
+
+        var params = new MapSqlParameterSource();
+        params.addValue("pk_dsc_id", since);
+        params.addValue("max_dsc_batch_count", MAX_DSC_BATCH_COUNT);
+        params.addValue("before", importedBefore);
+
+        return jt.query(sql, params, new ClientCertRowMapper(certFormat));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<String> findActiveDSCKeyIds(Date importedBefore) {
+        String sql =
+                "select key_id from t_document_signer_certificate where imported_at < :before order by pk_dsc_id";
+        MapSqlParameterSource params = new MapSqlParameterSource();
+        params.addValue("before", importedBefore);
+        return jt.queryForList(sql, params, String.class);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public long findMaxDSCPkId() {
+        try {
+            String sql =
+                    "select pk_dsc_id from t_document_signer_certificate"
+                            + " order by pk_dsc_id desc"
+                            + " limit 1";
+            return jt.queryForObject(sql, new MapSqlParameterSource(), Long.class);
+        } catch (EmptyResultDataAccessException e) {
+            return 0L;
+        }
+    }
+
+    @Override
+    public int getMaxDSCBatchCount() {
+        return MAX_DSC_BATCH_COUNT;
+    }
+
+    private MapSqlParameterSource getCSCAParams(DbCsca dbCsca) {
+        var params = new MapSqlParameterSource();
+        params.addValue("key_id", dbCsca.getKeyId());
+        params.addValue("certificate_raw", dbCsca.getCertificateRaw());
+        params.addValue("origin", dbCsca.getOrigin());
+        params.addValue("subject_principal_name", dbCsca.getSubjectPrincipalName());
+        return params;
+    }
+
+    private MapSqlParameterSource getDSCParams(DbDsc dbDsc) {
+        var params = new MapSqlParameterSource();
+        params.addValue("key_id", dbDsc.getKeyId());
+        params.addValue("fk_csca_id", dbDsc.getFkCsca());
+        params.addValue("certificate_raw", dbDsc.getCertificateRaw());
+        params.addValue("origin", dbDsc.getOrigin());
+        params.addValue("use", dbDsc.getUse());
+        params.addValue("alg", dbDsc.getAlg().name());
+        params.addValue("n", dbDsc.getN());
+        params.addValue("e", dbDsc.getE());
+        params.addValue("subject_public_key_info", dbDsc.getSubjectPublicKeyInfo());
+        params.addValue("crv", dbDsc.getCrv());
+        params.addValue("x", dbDsc.getX());
+        params.addValue("y", dbDsc.getY());
+        return params;
+    }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/impl/JdbcVerifierDataServiceImpl.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/impl/JdbcVerifierDataServiceImpl.java
@@ -18,6 +18,7 @@ import ch.admin.bag.covidcertificate.backend.verifier.model.cert.ClientCert;
 import ch.admin.bag.covidcertificate.backend.verifier.model.cert.db.DbCsca;
 import ch.admin.bag.covidcertificate.backend.verifier.model.cert.db.DbDsc;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.sql.DataSource;
@@ -32,195 +33,199 @@ import org.springframework.transaction.annotation.Transactional;
 
 public class JdbcVerifierDataServiceImpl implements VerifierDataService {
 
-    private static final Logger logger = LoggerFactory.getLogger(JdbcVerifierDataServiceImpl.class);
+  private static final Logger logger = LoggerFactory.getLogger(JdbcVerifierDataServiceImpl.class);
 
-    private static final int MAX_DSC_BATCH_COUNT = 1000;
-    private final NamedParameterJdbcTemplate jt;
-    private final SimpleJdbcInsert cscaInsert;
-    private final SimpleJdbcInsert dscInsert;
+  private static final int MAX_DSC_BATCH_COUNT = 1000;
+  private final NamedParameterJdbcTemplate jt;
+  private final SimpleJdbcInsert cscaInsert;
+  private final SimpleJdbcInsert dscInsert;
 
-    public JdbcVerifierDataServiceImpl(DataSource dataSource) {
-        this.jt = new NamedParameterJdbcTemplate(dataSource);
-        this.cscaInsert =
-                new SimpleJdbcInsert(dataSource)
-                        .withTableName("t_country_specific_certificate_authority")
-                        .usingGeneratedKeyColumns("pk_csca_id", "imported_at");
-        this.dscInsert =
-                new SimpleJdbcInsert(dataSource)
-                        .withTableName("t_document_signer_certificate")
-                        .usingGeneratedKeyColumns("pk_dsc_id", "imported_at");
+  public JdbcVerifierDataServiceImpl(DataSource dataSource) {
+    this.jt = new NamedParameterJdbcTemplate(dataSource);
+    this.cscaInsert =
+        new SimpleJdbcInsert(dataSource)
+            .withTableName("t_country_specific_certificate_authority")
+            .usingGeneratedKeyColumns("pk_csca_id", "imported_at");
+    this.dscInsert =
+        new SimpleJdbcInsert(dataSource)
+            .withTableName("t_document_signer_certificate")
+            .usingGeneratedKeyColumns("pk_dsc_id", "imported_at");
+  }
+
+  @Override
+  @Transactional
+  public void insertCSCAs(List<DbCsca> cscas) {
+    logger.debug(
+        "Inserting CSCA certificates with kid's: {}",
+        cscas.stream().map(DbCsca::getKeyId).collect(Collectors.toList()));
+    List<SqlParameterSource> batchParams = new ArrayList<>();
+    if (!cscas.isEmpty()) {
+      for (DbCsca dbCsca : cscas) {
+        batchParams.add(getCSCAParams(dbCsca));
+      }
+      cscaInsert.executeBatch(batchParams.toArray(new SqlParameterSource[batchParams.size()]));
     }
+  }
 
-    @Override
-    @Transactional
-    public void insertCSCAs(List<DbCsca> cscas) {
-        logger.debug(
-                "Inserting CSCA certificates with kid's: {}",
-                cscas.stream().map(DbCsca::getKeyId).collect(Collectors.toList()));
-        List<SqlParameterSource> batchParams = new ArrayList<>();
-        if (!cscas.isEmpty()) {
-            for (DbCsca dbCsca : cscas) {
-                batchParams.add(getCSCAParams(dbCsca));
-            }
-            cscaInsert.executeBatch(
-                    batchParams.toArray(new SqlParameterSource[batchParams.size()]));
-        }
+  @Override
+  @Transactional
+  public int removeCSCAs(List<String> keyIds) {
+    if (!keyIds.isEmpty()) {
+      var sql = "delete from t_country_specific_certificate_authority";
+      final var params = new MapSqlParameterSource();
+      sql += " where key_id in (:kids)";
+      params.addValue("kids", keyIds);
+      return jt.update(sql, params);
+    } else {
+      return 0;
     }
+  }
 
-    @Override
-    @Transactional
-    public int removeCSCAs(List<String> keyIds) {
-        if (!keyIds.isEmpty()) {
-            var sql = "delete from t_country_specific_certificate_authority";
-            final var params = new MapSqlParameterSource();
-            sql += " where key_id in (:kids)";
-            params.addValue("kids", keyIds);
-            return jt.update(sql, params);
-        } else {
-            return 0;
-        }
+  @Override
+  @Transactional(readOnly = true)
+  public List<DbCsca> findCSCAs(String origin) {
+    final var sql = "select * from t_country_specific_certificate_authority where origin = :origin";
+    final var params = new MapSqlParameterSource();
+    params.addValue("origin", origin);
+    return jt.query(sql, params, new CSCARowMapper());
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<String> findActiveCSCAKeyIds() {
+    final var sql = "select key_id from t_country_specific_certificate_authority";
+    return jt.queryForList(sql, new MapSqlParameterSource(), String.class);
+  }
+
+  @Override
+  @Transactional
+  public void insertDSCs(List<DbDsc> dsc) {
+    List<SqlParameterSource> batchParams = new ArrayList<>();
+    if (!dsc.isEmpty()) {
+      for (DbDsc dbDsc : dsc) {
+        batchParams.add(getDSCParams(dbDsc));
+      }
+      dscInsert.executeBatch(batchParams.toArray(new SqlParameterSource[batchParams.size()]));
     }
+  }
 
-    @Override
-    @Transactional(readOnly = true)
-    public List<DbCsca> findCSCAs(String origin) {
-        final var sql =
-                "select * from t_country_specific_certificate_authority where origin = :origin";
-        final var params = new MapSqlParameterSource();
-        params.addValue("origin", origin);
-        return jt.query(sql, params, new CSCARowMapper());
+  @Override
+  @Transactional
+  public int removeDSCsNotIn(List<String> keyIdsToKeep) {
+    var sql = "delete from t_document_signer_certificate";
+    final var params = new MapSqlParameterSource();
+    if (!keyIdsToKeep.isEmpty()) {
+      sql += " where key_id not in (:kids)";
+      params.addValue("kids", keyIdsToKeep);
     }
+    return jt.update(sql, params);
+  }
 
-    @Override
-    @Transactional(readOnly = true)
-    public List<String> findActiveCSCAKeyIds() {
-        final var sql = "select key_id from t_country_specific_certificate_authority";
-        return jt.queryForList(sql, new MapSqlParameterSource(), String.class);
+  @Override
+  @Transactional
+  public int removeDSCsWithCSCAIn(List<String> cscaKidsToRemove) {
+    if (!cscaKidsToRemove.isEmpty()) {
+      var sql = "delete from t_document_signer_certificate where fk_csca_id in (:fk_csca_id)";
+      final var params = new MapSqlParameterSource();
+      params.addValue("fk_csca_id", findCscaPksForKids(cscaKidsToRemove));
+      return jt.update(sql, params);
+    } else {
+      return 0;
     }
+  }
 
-    @Override
-    @Transactional
-    public void insertDSCs(List<DbDsc> dsc) {
-        List<SqlParameterSource> batchParams = new ArrayList<>();
-        if (!dsc.isEmpty()) {
-            for (DbDsc dbDsc : dsc) {
-                batchParams.add(getDSCParams(dbDsc));
-            }
-            dscInsert.executeBatch(batchParams.toArray(new SqlParameterSource[batchParams.size()]));
-        }
+  private List<Long> findCscaPksForKids(List<String> cscaKids) {
+    if (!cscaKids.isEmpty()) {
+      final var sql =
+          "select pk_csca_id from t_country_specific_certificate_authority where key_id in (:kids)";
+      final var params = new MapSqlParameterSource();
+      params.addValue("kids", cscaKids);
+      return jt.queryForList(sql, params, Long.class);
+    } else {
+      return new ArrayList<>();
     }
+  }
 
-    @Override
-    @Transactional
-    public int removeDSCsNotIn(List<String> keyIdsToKeep) {
-        var sql = "delete from t_document_signer_certificate";
-        final var params = new MapSqlParameterSource();
-        if (!keyIdsToKeep.isEmpty()) {
-            sql += " where key_id not in (:kids)";
-            params.addValue("kids", keyIdsToKeep);
-        }
-        return jt.update(sql, params);
+  @Override
+  @Transactional(readOnly = true)
+  public List<ClientCert> findDSCs(Long since, CertFormat certFormat, Date importedBefore) {
+    String sql =
+        "select pk_dsc_id,"
+            + " key_id,"
+            + " origin,"
+            + " use,"
+            + " alg,"
+            + " crv,"
+            + " x,"
+            + " y, "
+            + "subject_public_key_info, "
+            + "n, e"
+            + " from t_document_signer_certificate"
+            + " where pk_dsc_id > :pk_dsc_id"
+            + " and imported_at < :before"
+            + " order by pk_dsc_id asc"
+            + " limit :max_dsc_batch_count";
+
+    var params = new MapSqlParameterSource();
+    params.addValue("pk_dsc_id", since);
+    params.addValue("max_dsc_batch_count", MAX_DSC_BATCH_COUNT);
+    params.addValue("before", importedBefore);
+
+    return jt.query(sql, params, new ClientCertRowMapper(certFormat));
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<String> findActiveDSCKeyIds(Date importedBefore) {
+    String sql =
+        "select key_id from t_document_signer_certificate where imported_at < :before order by pk_dsc_id";
+    MapSqlParameterSource params = new MapSqlParameterSource();
+    params.addValue("before", importedBefore);
+    return jt.queryForList(sql, params, String.class);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public long findMaxDSCPkId() {
+    try {
+      String sql =
+          "select pk_dsc_id from t_document_signer_certificate"
+              + " order by pk_dsc_id desc"
+              + " limit 1";
+      return jt.queryForObject(sql, new MapSqlParameterSource(), Long.class);
+    } catch (EmptyResultDataAccessException e) {
+      return 0L;
     }
+  }
 
-    @Override
-    @Transactional
-    public int removeDSCsWithCSCAIn(List<String> cscaKidsToRemove) {
-        if (!cscaKidsToRemove.isEmpty()) {
-            var sql = "delete from t_document_signer_certificate where fk_csca_id in (:fk_csca_id)";
-            final var params = new MapSqlParameterSource();
-            params.addValue("fk_csca_id", findCscaPksForKids(cscaKidsToRemove));
-            return jt.update(sql, params);
-        } else {
-            return 0;
-        }
-    }
+  @Override
+  public int getMaxDSCBatchCount() {
+    return MAX_DSC_BATCH_COUNT;
+  }
 
-    private List<Long> findCscaPksForKids(List<String> cscaKids) {
-        if (!cscaKids.isEmpty()) {
-            final var sql =
-                    "select pk_csca_id from t_country_specific_certificate_authority where key_id in (:kids)";
-            final var params = new MapSqlParameterSource();
-            params.addValue("kids", cscaKids);
-            return jt.queryForList(sql, params, Long.class);
-        } else {
-            return new ArrayList<>();
-        }
-    }
+  private MapSqlParameterSource getCSCAParams(DbCsca dbCsca) {
+    var params = new MapSqlParameterSource();
+    params.addValue("key_id", dbCsca.getKeyId());
+    params.addValue("certificate_raw", dbCsca.getCertificateRaw());
+    params.addValue("origin", dbCsca.getOrigin());
+    params.addValue("subject_principal_name", dbCsca.getSubjectPrincipalName());
+    return params;
+  }
 
-    @Override
-    @Transactional(readOnly = true)
-    public List<ClientCert> findDSCs(Long since, CertFormat certFormat) {
-        String sql =
-                "select pk_dsc_id,"
-                        + " key_id,"
-                        + " origin,"
-                        + " use,"
-                        + " alg,"
-                        + " crv,"
-                        + " x,"
-                        + " y, "
-                        + "subject_public_key_info, "
-                        + "n, e"
-                        + " from t_document_signer_certificate"
-                        + " where pk_dsc_id > :pk_dsc_id"
-                        + " order by pk_dsc_id asc"
-                        + " limit :max_dsc_batch_count";
-
-        var params = new MapSqlParameterSource();
-        params.addValue("pk_dsc_id", since);
-        params.addValue("max_dsc_batch_count", MAX_DSC_BATCH_COUNT);
-        return jt.query(sql, params, new ClientCertRowMapper(certFormat));
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public List<String> findActiveDSCKeyIds() {
-        String sql = "select key_id from t_document_signer_certificate order by pk_dsc_id";
-        return jt.queryForList(sql, new MapSqlParameterSource(), String.class);
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public long findMaxDSCPkId() {
-        try {
-            String sql =
-                    "select pk_dsc_id from t_document_signer_certificate"
-                            + " order by pk_dsc_id desc"
-                            + " limit 1";
-            return jt.queryForObject(sql, new MapSqlParameterSource(), Long.class);
-        } catch (EmptyResultDataAccessException e) {
-            return 0L;
-        }
-    }
-
-    @Override
-    public int getMaxDSCBatchCount() {
-        return MAX_DSC_BATCH_COUNT;
-    }
-
-    private MapSqlParameterSource getCSCAParams(DbCsca dbCsca) {
-        var params = new MapSqlParameterSource();
-        params.addValue("key_id", dbCsca.getKeyId());
-        params.addValue("certificate_raw", dbCsca.getCertificateRaw());
-        params.addValue("origin", dbCsca.getOrigin());
-        params.addValue("subject_principal_name", dbCsca.getSubjectPrincipalName());
-        return params;
-    }
-
-    private MapSqlParameterSource getDSCParams(DbDsc dbDsc) {
-        var params = new MapSqlParameterSource();
-        params.addValue("key_id", dbDsc.getKeyId());
-        params.addValue("fk_csca_id", dbDsc.getFkCsca());
-        params.addValue("certificate_raw", dbDsc.getCertificateRaw());
-        params.addValue("origin", dbDsc.getOrigin());
-        params.addValue("use", dbDsc.getUse());
-        params.addValue("alg", dbDsc.getAlg().name());
-        params.addValue("n", dbDsc.getN());
-        params.addValue("e", dbDsc.getE());
-        params.addValue("subject_public_key_info", dbDsc.getSubjectPublicKeyInfo());
-        params.addValue("crv", dbDsc.getCrv());
-        params.addValue("x", dbDsc.getX());
-        params.addValue("y", dbDsc.getY());
-        return params;
-    }
+  private MapSqlParameterSource getDSCParams(DbDsc dbDsc) {
+    var params = new MapSqlParameterSource();
+    params.addValue("key_id", dbDsc.getKeyId());
+    params.addValue("fk_csca_id", dbDsc.getFkCsca());
+    params.addValue("certificate_raw", dbDsc.getCertificateRaw());
+    params.addValue("origin", dbDsc.getOrigin());
+    params.addValue("use", dbDsc.getUse());
+    params.addValue("alg", dbDsc.getAlg().name());
+    params.addValue("n", dbDsc.getN());
+    params.addValue("e", dbDsc.getE());
+    params.addValue("subject_public_key_info", dbDsc.getSubjectPublicKeyInfo());
+    params.addValue("crv", dbDsc.getCrv());
+    params.addValue("x", dbDsc.getX());
+    params.addValue("y", dbDsc.getY());
+    return params;
+  }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/data/VerifierDataServiceTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/data/VerifierDataServiceTest.java
@@ -1,7 +1,6 @@
 package ch.admin.bag.covidcertificate.backend.verifier.data;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -10,6 +9,7 @@ import ch.admin.bag.covidcertificate.backend.verifier.model.cert.CertFormat;
 import ch.admin.bag.covidcertificate.backend.verifier.model.cert.db.DbCsca;
 import ch.admin.bag.covidcertificate.backend.verifier.model.cert.db.DbDsc;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,161 +17,160 @@ import org.springframework.transaction.annotation.Transactional;
 
 class VerifierDataServiceTest extends BaseDataServiceTest {
 
-    @Autowired VerifierDataService verifierDataService;
+  @Autowired VerifierDataService verifierDataService;
 
-    @Test
-    @Transactional
-    void insertCscasTest() {
-        verifierDataService.insertCSCAs(Collections.emptyList());
-        assertTrue(verifierDataService.findCSCAs("CH").isEmpty());
-        var dbCsca = getDefaultCSCA(0, "CH");
-        verifierDataService.insertCSCAs(Collections.singletonList(dbCsca));
-        final var certList = verifierDataService.findCSCAs("CH");
-        assertEquals(1, certList.size());
-        assertEquals(dbCsca.getKeyId(), certList.get(0).getKeyId());
-        assertNotNull(certList.get(0).getImportedAt());
-    }
+  @Test
+  @Transactional
+  void insertCscasTest() {
+    verifierDataService.insertCSCAs(Collections.emptyList());
+    assertTrue(verifierDataService.findCSCAs("CH").isEmpty());
+    var dbCsca = getDefaultCSCA(0, "CH");
+    verifierDataService.insertCSCAs(Collections.singletonList(dbCsca));
+    final var certList = verifierDataService.findCSCAs("CH");
+    assertEquals(1, certList.size());
+    assertEquals(dbCsca.getKeyId(), certList.get(0).getKeyId());
+    assertNotNull(certList.get(0).getImportedAt());
+  }
 
-    @Test
-    @Transactional
-    void removeCscasNotInTest() {
-        assertTrue(verifierDataService.findCSCAs("CH").isEmpty());
-        verifierDataService.removeCSCAs(Collections.emptyList());
-        verifierDataService.removeCSCAs(Collections.singletonList("keyid_0"));
-        verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(0, "CH")));
-        verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(1, "CH")));
-        verifierDataService.removeCSCAs(Collections.singletonList("keyid_0"));
-        assertEquals(1, verifierDataService.findCSCAs("CH").size());
-    }
+  @Test
+  @Transactional
+  void removeCscasNotInTest() {
+    assertTrue(verifierDataService.findCSCAs("CH").isEmpty());
+    verifierDataService.removeCSCAs(Collections.emptyList());
+    verifierDataService.removeCSCAs(Collections.singletonList("keyid_0"));
+    verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(0, "CH")));
+    verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(1, "CH")));
+    verifierDataService.removeCSCAs(Collections.singletonList("keyid_0"));
+    assertEquals(1, verifierDataService.findCSCAs("CH").size());
+  }
 
-    @Test
-    @Transactional
-    void findCscaTest() {
-        verifierDataService.insertCSCAs(List.of(getDefaultCSCA(0, "CH"), getDefaultCSCA(1, "DE")));
-        assertEquals(1, verifierDataService.findCSCAs("CH").size());
-    }
+  @Test
+  @Transactional
+  void findCscaTest() {
+    verifierDataService.insertCSCAs(List.of(getDefaultCSCA(0, "CH"), getDefaultCSCA(1, "DE")));
+    assertEquals(1, verifierDataService.findCSCAs("CH").size());
+  }
 
-    @Test
-    @Transactional
-    void findActiveCscaKeyIdsTest() {
-        final var chCSCA = getDefaultCSCA(0, "CH");
-        final var deCSCA = getDefaultCSCA(1, "DE");
-        verifierDataService.insertCSCAs(List.of(chCSCA, deCSCA));
-        final var actualKeyIds = List.of(chCSCA.getKeyId(), deCSCA.getKeyId());
-        final var activeCscaKeyIds = verifierDataService.findActiveCSCAKeyIds();
-        assertTrue(
-                activeCscaKeyIds.size() == actualKeyIds.size()
-                        && activeCscaKeyIds.containsAll(actualKeyIds)
-                        && actualKeyIds.containsAll(activeCscaKeyIds));
-    }
+  @Test
+  @Transactional
+  void findActiveCscaKeyIdsTest() {
+    final var chCSCA = getDefaultCSCA(0, "CH");
+    final var deCSCA = getDefaultCSCA(1, "DE");
+    verifierDataService.insertCSCAs(List.of(chCSCA, deCSCA));
+    final var actualKeyIds = List.of(chCSCA.getKeyId(), deCSCA.getKeyId());
+    final var activeCscaKeyIds = verifierDataService.findActiveCSCAKeyIds();
+    assertTrue(
+        activeCscaKeyIds.size() == actualKeyIds.size()
+            && activeCscaKeyIds.containsAll(actualKeyIds)
+            && actualKeyIds.containsAll(activeCscaKeyIds));
+  }
 
-    @Test
-    @Transactional
-    void insertDscTest() {
-        verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(0, "CH")));
-        final var cscaId = verifierDataService.findCSCAs("CH").get(0).getId();
-        verifierDataService.insertDSCs(Collections.emptyList());
-        assertTrue(verifierDataService.findActiveDSCKeyIds().isEmpty());
-        final var rsaDsc = getRSADsc(0, "CH", cscaId);
-        verifierDataService.insertDSCs(Collections.singletonList(rsaDsc));
-        assertEquals(1, verifierDataService.findActiveDSCKeyIds().size());
-        assertEquals(
-                rsaDsc.getKeyId(),
-                verifierDataService.findDSCs(0L, CertFormat.ANDROID).get(0).getKeyId());
-    }
+  @Test
+  @Transactional
+  void insertDscTest() {
+    verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(0, "CH")));
+    final var cscaId = verifierDataService.findCSCAs("CH").get(0).getId();
+    verifierDataService.insertDSCs(Collections.emptyList());
+    assertTrue(verifierDataService.findActiveDSCKeyIds(new Date()).isEmpty());
+    final var rsaDsc = getRSADsc(0, "CH", cscaId);
+    verifierDataService.insertDSCs(Collections.singletonList(rsaDsc));
+    assertEquals(1, verifierDataService.findActiveDSCKeyIds(new Date()).size());
+    assertEquals(
+        rsaDsc.getKeyId(),
+        verifierDataService.findDSCs(0L, CertFormat.ANDROID, new Date()).get(0).getKeyId());
+  }
 
-    @Test
-    @Transactional
-    void removeDscsNotInTest() {
-        verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(0, "CH")));
-        final var cscas = verifierDataService.findCSCAs("CH");
-        assertEquals(1, cscas.size());
-        final var cscaId = cscas.get(0).getId();
-        final var rsaDsc = getRSADsc(0, "CH", cscaId);
-        verifierDataService.insertDSCs(Collections.singletonList(rsaDsc));
-        verifierDataService.removeDSCsNotIn(Collections.emptyList());
-        assertTrue(verifierDataService.findActiveDSCKeyIds().isEmpty());
-        verifierDataService.removeDSCsNotIn(Collections.singletonList("keyid_0"));
-        final var ecDsc = getECDsc(1, "CH", cscaId);
-        verifierDataService.insertDSCs(List.of(rsaDsc, ecDsc));
-        verifierDataService.removeDSCsNotIn(Collections.singletonList(rsaDsc.getKeyId()));
-        assertEquals(1, verifierDataService.findActiveDSCKeyIds().size());
-    }
+  @Test
+  @Transactional
+  void removeDscsNotInTest() {
+    verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(0, "CH")));
+    final var cscas = verifierDataService.findCSCAs("CH");
+    assertEquals(1, cscas.size());
+    final var cscaId = cscas.get(0).getId();
+    final var rsaDsc = getRSADsc(0, "CH", cscaId);
+    verifierDataService.insertDSCs(Collections.singletonList(rsaDsc));
+    verifierDataService.removeDSCsNotIn(Collections.emptyList());
+    assertTrue(verifierDataService.findActiveDSCKeyIds(new Date()).isEmpty());
+    verifierDataService.removeDSCsNotIn(Collections.singletonList("keyid_0"));
+    final var ecDsc = getECDsc(1, "CH", cscaId);
+    verifierDataService.insertDSCs(List.of(rsaDsc, ecDsc));
+    verifierDataService.removeDSCsNotIn(Collections.singletonList(rsaDsc.getKeyId()));
+    assertEquals(1, verifierDataService.findActiveDSCKeyIds(new Date()).size());
+  }
 
-    @Test
-    @Transactional
-    void removeDscsWithCSCAIn() {
-        verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(0, "DE")));
-        verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(1, "DE")));
-        final var cscas = verifierDataService.findCSCAs("DE");
-        assertEquals(2, cscas.size());
-        final var cscaId0 = cscas.get(0).getId();
-        final var cscaId1 = cscas.get(1).getId();
-        final var rsaDsc = getRSADsc(0, "DE", cscaId0);
-        final var ecDsc = getECDsc(1, "DE", cscaId1);
-        verifierDataService.insertDSCs(List.of(rsaDsc, ecDsc));
-        verifierDataService.removeDSCsWithCSCAIn(Collections.emptyList());
-        assertEquals(2, verifierDataService.findActiveDSCKeyIds().size());
-        verifierDataService.removeDSCsWithCSCAIn(List.of(cscas.get(0).getKeyId()));
-        assertEquals(1, verifierDataService.findActiveDSCKeyIds().size());
-    }
+  @Test
+  @Transactional
+  void removeDscsWithCSCAIn() {
+    verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(0, "DE")));
+    verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(1, "DE")));
+    final var cscas = verifierDataService.findCSCAs("DE");
+    assertEquals(2, cscas.size());
+    final var cscaId0 = cscas.get(0).getId();
+    final var cscaId1 = cscas.get(1).getId();
+    final var rsaDsc = getRSADsc(0, "DE", cscaId0);
+    final var ecDsc = getECDsc(1, "DE", cscaId1);
+    verifierDataService.insertDSCs(List.of(rsaDsc, ecDsc));
+    verifierDataService.removeDSCsWithCSCAIn(Collections.emptyList());
+    assertEquals(2, verifierDataService.findActiveDSCKeyIds(new Date()).size());
+    verifierDataService.removeDSCsWithCSCAIn(List.of(cscas.get(0).getKeyId()));
+    assertEquals(1, verifierDataService.findActiveDSCKeyIds(new Date()).size());
+  }
 
-    @Test
-    @Transactional
-    void findDscsTest() {
-        verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(0, "CH")));
-        final var cscaId = verifierDataService.findCSCAs("CH").get(0).getId();
-        verifierDataService.insertDSCs(
-                List.of(getRSADsc(0, "CH", cscaId), getECDsc(1, "DE", cscaId)));
-        assertEquals(2, verifierDataService.findDSCs(0L, CertFormat.IOS).size());
-    }
+  @Test
+  @Transactional
+  void findDscsTest() {
+    verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(0, "CH")));
+    final var cscaId = verifierDataService.findCSCAs("CH").get(0).getId();
+    verifierDataService.insertDSCs(List.of(getRSADsc(0, "CH", cscaId), getECDsc(1, "DE", cscaId)));
+    assertEquals(2, verifierDataService.findDSCs(0L, CertFormat.IOS, new Date()).size());
+  }
 
-    @Test
-    @Transactional
-    void findMaxDscsTest() {
-        verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(0, "CH")));
-        final var cscaId = verifierDataService.findCSCAs("CH").get(0).getId();
-        verifierDataService.insertDSCs(
-                List.of(getRSADsc(0, "CH", cscaId), getECDsc(1, "DE", cscaId)));
-        final var maxDscPkId = verifierDataService.findMaxDSCPkId();
-        assertTrue(verifierDataService.findDSCs(maxDscPkId, CertFormat.IOS).isEmpty());
-        assertEquals(1, verifierDataService.findDSCs(maxDscPkId - 1, CertFormat.IOS).size());
-    }
+  @Test
+  @Transactional
+  void findMaxDscsTest() {
+    verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(0, "CH")));
+    final var cscaId = verifierDataService.findCSCAs("CH").get(0).getId();
+    verifierDataService.insertDSCs(List.of(getRSADsc(0, "CH", cscaId), getECDsc(1, "DE", cscaId)));
+    final var maxDscPkId = verifierDataService.findMaxDSCPkId();
+    assertTrue(verifierDataService.findDSCs(maxDscPkId, CertFormat.IOS, new Date()).isEmpty());
+    assertEquals(
+        1, verifierDataService.findDSCs(maxDscPkId - 1, CertFormat.IOS, new Date()).size());
+  }
 
-    private DbCsca getDefaultCSCA(int idSuffix, String origin) {
-        var dbCsca = new DbCsca();
-        dbCsca.setKeyId("keyid_" + idSuffix);
-        dbCsca.setCertificateRaw("cert");
-        dbCsca.setOrigin(origin);
-        dbCsca.setSubjectPrincipalName("admin_ch");
-        return dbCsca;
-    }
+  private DbCsca getDefaultCSCA(int idSuffix, String origin) {
+    var dbCsca = new DbCsca();
+    dbCsca.setKeyId("keyid_" + idSuffix);
+    dbCsca.setCertificateRaw("cert");
+    dbCsca.setOrigin(origin);
+    dbCsca.setSubjectPrincipalName("admin_ch");
+    return dbCsca;
+  }
 
-    private DbDsc getRSADsc(int idSuffix, String origin, long fkCsca) {
-        final var dbDsc = new DbDsc();
-        dbDsc.setKeyId("keyid_" + idSuffix);
-        dbDsc.setFkCsca(fkCsca);
-        dbDsc.setCertificateRaw("cert");
-        dbDsc.setOrigin(origin);
-        dbDsc.setUse("DSC");
-        dbDsc.setAlg(Algorithm.RS256);
-        dbDsc.setN("n");
-        dbDsc.setE("e");
-        dbDsc.setSubjectPublicKeyInfo("pk");
-        return dbDsc;
-    }
+  private DbDsc getRSADsc(int idSuffix, String origin, long fkCsca) {
+    final var dbDsc = new DbDsc();
+    dbDsc.setKeyId("keyid_" + idSuffix);
+    dbDsc.setFkCsca(fkCsca);
+    dbDsc.setCertificateRaw("cert");
+    dbDsc.setOrigin(origin);
+    dbDsc.setUse("DSC");
+    dbDsc.setAlg(Algorithm.RS256);
+    dbDsc.setN("n");
+    dbDsc.setE("e");
+    dbDsc.setSubjectPublicKeyInfo("pk");
+    return dbDsc;
+  }
 
-    private DbDsc getECDsc(int idSuffix, String origin, long fkCsca) {
-        final var dbDsc = new DbDsc();
-        dbDsc.setKeyId("keyid_" + idSuffix);
-        dbDsc.setFkCsca(fkCsca);
-        dbDsc.setCertificateRaw("cert");
-        dbDsc.setOrigin(origin);
-        dbDsc.setUse("DSC");
-        dbDsc.setAlg(Algorithm.ES256);
-        dbDsc.setCrv("crv");
-        dbDsc.setX("x");
-        dbDsc.setY("y");
-        return dbDsc;
-    }
+  private DbDsc getECDsc(int idSuffix, String origin, long fkCsca) {
+    final var dbDsc = new DbDsc();
+    dbDsc.setKeyId("keyid_" + idSuffix);
+    dbDsc.setFkCsca(fkCsca);
+    dbDsc.setCertificateRaw("cert");
+    dbDsc.setOrigin(origin);
+    dbDsc.setUse("DSC");
+    dbDsc.setAlg(Algorithm.ES256);
+    dbDsc.setCrv("crv");
+    dbDsc.setX("x");
+    dbDsc.setY("y");
+    return dbDsc;
+  }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/data/VerifierDataServiceTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/data/VerifierDataServiceTest.java
@@ -17,160 +17,162 @@ import org.springframework.transaction.annotation.Transactional;
 
 class VerifierDataServiceTest extends BaseDataServiceTest {
 
-  @Autowired VerifierDataService verifierDataService;
+    @Autowired VerifierDataService verifierDataService;
 
-  @Test
-  @Transactional
-  void insertCscasTest() {
-    verifierDataService.insertCSCAs(Collections.emptyList());
-    assertTrue(verifierDataService.findCSCAs("CH").isEmpty());
-    var dbCsca = getDefaultCSCA(0, "CH");
-    verifierDataService.insertCSCAs(Collections.singletonList(dbCsca));
-    final var certList = verifierDataService.findCSCAs("CH");
-    assertEquals(1, certList.size());
-    assertEquals(dbCsca.getKeyId(), certList.get(0).getKeyId());
-    assertNotNull(certList.get(0).getImportedAt());
-  }
+    @Test
+    @Transactional
+    void insertCscasTest() {
+        verifierDataService.insertCSCAs(Collections.emptyList());
+        assertTrue(verifierDataService.findCSCAs("CH").isEmpty());
+        var dbCsca = getDefaultCSCA(0, "CH");
+        verifierDataService.insertCSCAs(Collections.singletonList(dbCsca));
+        final var certList = verifierDataService.findCSCAs("CH");
+        assertEquals(1, certList.size());
+        assertEquals(dbCsca.getKeyId(), certList.get(0).getKeyId());
+        assertNotNull(certList.get(0).getImportedAt());
+    }
 
-  @Test
-  @Transactional
-  void removeCscasNotInTest() {
-    assertTrue(verifierDataService.findCSCAs("CH").isEmpty());
-    verifierDataService.removeCSCAs(Collections.emptyList());
-    verifierDataService.removeCSCAs(Collections.singletonList("keyid_0"));
-    verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(0, "CH")));
-    verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(1, "CH")));
-    verifierDataService.removeCSCAs(Collections.singletonList("keyid_0"));
-    assertEquals(1, verifierDataService.findCSCAs("CH").size());
-  }
+    @Test
+    @Transactional
+    void removeCscasNotInTest() {
+        assertTrue(verifierDataService.findCSCAs("CH").isEmpty());
+        verifierDataService.removeCSCAs(Collections.emptyList());
+        verifierDataService.removeCSCAs(Collections.singletonList("keyid_0"));
+        verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(0, "CH")));
+        verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(1, "CH")));
+        verifierDataService.removeCSCAs(Collections.singletonList("keyid_0"));
+        assertEquals(1, verifierDataService.findCSCAs("CH").size());
+    }
 
-  @Test
-  @Transactional
-  void findCscaTest() {
-    verifierDataService.insertCSCAs(List.of(getDefaultCSCA(0, "CH"), getDefaultCSCA(1, "DE")));
-    assertEquals(1, verifierDataService.findCSCAs("CH").size());
-  }
+    @Test
+    @Transactional
+    void findCscaTest() {
+        verifierDataService.insertCSCAs(List.of(getDefaultCSCA(0, "CH"), getDefaultCSCA(1, "DE")));
+        assertEquals(1, verifierDataService.findCSCAs("CH").size());
+    }
 
-  @Test
-  @Transactional
-  void findActiveCscaKeyIdsTest() {
-    final var chCSCA = getDefaultCSCA(0, "CH");
-    final var deCSCA = getDefaultCSCA(1, "DE");
-    verifierDataService.insertCSCAs(List.of(chCSCA, deCSCA));
-    final var actualKeyIds = List.of(chCSCA.getKeyId(), deCSCA.getKeyId());
-    final var activeCscaKeyIds = verifierDataService.findActiveCSCAKeyIds();
-    assertTrue(
-        activeCscaKeyIds.size() == actualKeyIds.size()
-            && activeCscaKeyIds.containsAll(actualKeyIds)
-            && actualKeyIds.containsAll(activeCscaKeyIds));
-  }
+    @Test
+    @Transactional
+    void findActiveCscaKeyIdsTest() {
+        final var chCSCA = getDefaultCSCA(0, "CH");
+        final var deCSCA = getDefaultCSCA(1, "DE");
+        verifierDataService.insertCSCAs(List.of(chCSCA, deCSCA));
+        final var actualKeyIds = List.of(chCSCA.getKeyId(), deCSCA.getKeyId());
+        final var activeCscaKeyIds = verifierDataService.findActiveCSCAKeyIds();
+        assertTrue(
+                activeCscaKeyIds.size() == actualKeyIds.size()
+                        && activeCscaKeyIds.containsAll(actualKeyIds)
+                        && actualKeyIds.containsAll(activeCscaKeyIds));
+    }
 
-  @Test
-  @Transactional
-  void insertDscTest() {
-    verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(0, "CH")));
-    final var cscaId = verifierDataService.findCSCAs("CH").get(0).getId();
-    verifierDataService.insertDSCs(Collections.emptyList());
-    assertTrue(verifierDataService.findActiveDSCKeyIds(new Date()).isEmpty());
-    final var rsaDsc = getRSADsc(0, "CH", cscaId);
-    verifierDataService.insertDSCs(Collections.singletonList(rsaDsc));
-    assertEquals(1, verifierDataService.findActiveDSCKeyIds(new Date()).size());
-    assertEquals(
-        rsaDsc.getKeyId(),
-        verifierDataService.findDSCs(0L, CertFormat.ANDROID, new Date()).get(0).getKeyId());
-  }
+    @Test
+    @Transactional
+    void insertDscTest() {
+        verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(0, "CH")));
+        final var cscaId = verifierDataService.findCSCAs("CH").get(0).getId();
+        verifierDataService.insertDSCs(Collections.emptyList());
+        assertTrue(verifierDataService.findActiveDSCKeyIds(new Date()).isEmpty());
+        final var rsaDsc = getRSADsc(0, "CH", cscaId);
+        verifierDataService.insertDSCs(Collections.singletonList(rsaDsc));
+        assertEquals(1, verifierDataService.findActiveDSCKeyIds(new Date()).size());
+        assertEquals(
+                rsaDsc.getKeyId(),
+                verifierDataService.findDSCs(0L, CertFormat.ANDROID, new Date()).get(0).getKeyId());
+    }
 
-  @Test
-  @Transactional
-  void removeDscsNotInTest() {
-    verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(0, "CH")));
-    final var cscas = verifierDataService.findCSCAs("CH");
-    assertEquals(1, cscas.size());
-    final var cscaId = cscas.get(0).getId();
-    final var rsaDsc = getRSADsc(0, "CH", cscaId);
-    verifierDataService.insertDSCs(Collections.singletonList(rsaDsc));
-    verifierDataService.removeDSCsNotIn(Collections.emptyList());
-    assertTrue(verifierDataService.findActiveDSCKeyIds(new Date()).isEmpty());
-    verifierDataService.removeDSCsNotIn(Collections.singletonList("keyid_0"));
-    final var ecDsc = getECDsc(1, "CH", cscaId);
-    verifierDataService.insertDSCs(List.of(rsaDsc, ecDsc));
-    verifierDataService.removeDSCsNotIn(Collections.singletonList(rsaDsc.getKeyId()));
-    assertEquals(1, verifierDataService.findActiveDSCKeyIds(new Date()).size());
-  }
+    @Test
+    @Transactional
+    void removeDscsNotInTest() {
+        verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(0, "CH")));
+        final var cscas = verifierDataService.findCSCAs("CH");
+        assertEquals(1, cscas.size());
+        final var cscaId = cscas.get(0).getId();
+        final var rsaDsc = getRSADsc(0, "CH", cscaId);
+        verifierDataService.insertDSCs(Collections.singletonList(rsaDsc));
+        verifierDataService.removeDSCsNotIn(Collections.emptyList());
+        assertTrue(verifierDataService.findActiveDSCKeyIds(new Date()).isEmpty());
+        verifierDataService.removeDSCsNotIn(Collections.singletonList("keyid_0"));
+        final var ecDsc = getECDsc(1, "CH", cscaId);
+        verifierDataService.insertDSCs(List.of(rsaDsc, ecDsc));
+        verifierDataService.removeDSCsNotIn(Collections.singletonList(rsaDsc.getKeyId()));
+        assertEquals(1, verifierDataService.findActiveDSCKeyIds(new Date()).size());
+    }
 
-  @Test
-  @Transactional
-  void removeDscsWithCSCAIn() {
-    verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(0, "DE")));
-    verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(1, "DE")));
-    final var cscas = verifierDataService.findCSCAs("DE");
-    assertEquals(2, cscas.size());
-    final var cscaId0 = cscas.get(0).getId();
-    final var cscaId1 = cscas.get(1).getId();
-    final var rsaDsc = getRSADsc(0, "DE", cscaId0);
-    final var ecDsc = getECDsc(1, "DE", cscaId1);
-    verifierDataService.insertDSCs(List.of(rsaDsc, ecDsc));
-    verifierDataService.removeDSCsWithCSCAIn(Collections.emptyList());
-    assertEquals(2, verifierDataService.findActiveDSCKeyIds(new Date()).size());
-    verifierDataService.removeDSCsWithCSCAIn(List.of(cscas.get(0).getKeyId()));
-    assertEquals(1, verifierDataService.findActiveDSCKeyIds(new Date()).size());
-  }
+    @Test
+    @Transactional
+    void removeDscsWithCSCAIn() {
+        verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(0, "DE")));
+        verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(1, "DE")));
+        final var cscas = verifierDataService.findCSCAs("DE");
+        assertEquals(2, cscas.size());
+        final var cscaId0 = cscas.get(0).getId();
+        final var cscaId1 = cscas.get(1).getId();
+        final var rsaDsc = getRSADsc(0, "DE", cscaId0);
+        final var ecDsc = getECDsc(1, "DE", cscaId1);
+        verifierDataService.insertDSCs(List.of(rsaDsc, ecDsc));
+        verifierDataService.removeDSCsWithCSCAIn(Collections.emptyList());
+        assertEquals(2, verifierDataService.findActiveDSCKeyIds(new Date()).size());
+        verifierDataService.removeDSCsWithCSCAIn(List.of(cscas.get(0).getKeyId()));
+        assertEquals(1, verifierDataService.findActiveDSCKeyIds(new Date()).size());
+    }
 
-  @Test
-  @Transactional
-  void findDscsTest() {
-    verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(0, "CH")));
-    final var cscaId = verifierDataService.findCSCAs("CH").get(0).getId();
-    verifierDataService.insertDSCs(List.of(getRSADsc(0, "CH", cscaId), getECDsc(1, "DE", cscaId)));
-    assertEquals(2, verifierDataService.findDSCs(0L, CertFormat.IOS, new Date()).size());
-  }
+    @Test
+    @Transactional
+    void findDscsTest() {
+        verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(0, "CH")));
+        final var cscaId = verifierDataService.findCSCAs("CH").get(0).getId();
+        verifierDataService.insertDSCs(
+                List.of(getRSADsc(0, "CH", cscaId), getECDsc(1, "DE", cscaId)));
+        assertEquals(2, verifierDataService.findDSCs(0L, CertFormat.IOS, new Date()).size());
+    }
 
-  @Test
-  @Transactional
-  void findMaxDscsTest() {
-    verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(0, "CH")));
-    final var cscaId = verifierDataService.findCSCAs("CH").get(0).getId();
-    verifierDataService.insertDSCs(List.of(getRSADsc(0, "CH", cscaId), getECDsc(1, "DE", cscaId)));
-    final var maxDscPkId = verifierDataService.findMaxDSCPkId();
-    assertTrue(verifierDataService.findDSCs(maxDscPkId, CertFormat.IOS, new Date()).isEmpty());
-    assertEquals(
-        1, verifierDataService.findDSCs(maxDscPkId - 1, CertFormat.IOS, new Date()).size());
-  }
+    @Test
+    @Transactional
+    void findMaxDscsTest() {
+        verifierDataService.insertCSCAs(Collections.singletonList(getDefaultCSCA(0, "CH")));
+        final var cscaId = verifierDataService.findCSCAs("CH").get(0).getId();
+        verifierDataService.insertDSCs(
+                List.of(getRSADsc(0, "CH", cscaId), getECDsc(1, "DE", cscaId)));
+        final var maxDscPkId = verifierDataService.findMaxDSCPkId();
+        assertTrue(verifierDataService.findDSCs(maxDscPkId, CertFormat.IOS, new Date()).isEmpty());
+        assertEquals(
+                1, verifierDataService.findDSCs(maxDscPkId - 1, CertFormat.IOS, new Date()).size());
+    }
 
-  private DbCsca getDefaultCSCA(int idSuffix, String origin) {
-    var dbCsca = new DbCsca();
-    dbCsca.setKeyId("keyid_" + idSuffix);
-    dbCsca.setCertificateRaw("cert");
-    dbCsca.setOrigin(origin);
-    dbCsca.setSubjectPrincipalName("admin_ch");
-    return dbCsca;
-  }
+    private DbCsca getDefaultCSCA(int idSuffix, String origin) {
+        var dbCsca = new DbCsca();
+        dbCsca.setKeyId("keyid_" + idSuffix);
+        dbCsca.setCertificateRaw("cert");
+        dbCsca.setOrigin(origin);
+        dbCsca.setSubjectPrincipalName("admin_ch");
+        return dbCsca;
+    }
 
-  private DbDsc getRSADsc(int idSuffix, String origin, long fkCsca) {
-    final var dbDsc = new DbDsc();
-    dbDsc.setKeyId("keyid_" + idSuffix);
-    dbDsc.setFkCsca(fkCsca);
-    dbDsc.setCertificateRaw("cert");
-    dbDsc.setOrigin(origin);
-    dbDsc.setUse("DSC");
-    dbDsc.setAlg(Algorithm.RS256);
-    dbDsc.setN("n");
-    dbDsc.setE("e");
-    dbDsc.setSubjectPublicKeyInfo("pk");
-    return dbDsc;
-  }
+    private DbDsc getRSADsc(int idSuffix, String origin, long fkCsca) {
+        final var dbDsc = new DbDsc();
+        dbDsc.setKeyId("keyid_" + idSuffix);
+        dbDsc.setFkCsca(fkCsca);
+        dbDsc.setCertificateRaw("cert");
+        dbDsc.setOrigin(origin);
+        dbDsc.setUse("DSC");
+        dbDsc.setAlg(Algorithm.RS256);
+        dbDsc.setN("n");
+        dbDsc.setE("e");
+        dbDsc.setSubjectPublicKeyInfo("pk");
+        return dbDsc;
+    }
 
-  private DbDsc getECDsc(int idSuffix, String origin, long fkCsca) {
-    final var dbDsc = new DbDsc();
-    dbDsc.setKeyId("keyid_" + idSuffix);
-    dbDsc.setFkCsca(fkCsca);
-    dbDsc.setCertificateRaw("cert");
-    dbDsc.setOrigin(origin);
-    dbDsc.setUse("DSC");
-    dbDsc.setAlg(Algorithm.ES256);
-    dbDsc.setCrv("crv");
-    dbDsc.setX("x");
-    dbDsc.setY("y");
-    return dbDsc;
-  }
+    private DbDsc getECDsc(int idSuffix, String origin, long fkCsca) {
+        final var dbDsc = new DbDsc();
+        dbDsc.setKeyId("keyid_" + idSuffix);
+        dbDsc.setFkCsca(fkCsca);
+        dbDsc.setCertificateRaw("cert");
+        dbDsc.setOrigin(origin);
+        dbDsc.setUse("DSC");
+        dbDsc.setAlg(Algorithm.ES256);
+        dbDsc.setCrv("crv");
+        dbDsc.setX("x");
+        dbDsc.setY("y");
+        return dbDsc;
+    }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-sync/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/sync/syncer/DGCSyncer.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-sync/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/sync/syncer/DGCSyncer.java
@@ -15,7 +15,9 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateExpiredException;
 import java.security.cert.CertificateNotYetValidException;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,7 +104,7 @@ public class DGCSyncer {
 
     private void downloadDSCs() {
         // Check which DSCs are currently stored in the db
-        final var activeDscKeyIds = verifierDataService.findActiveDSCKeyIds();
+        final var activeDscKeyIds = verifierDataService.findActiveDSCKeyIds(nowPlus1Min());
         // Download and insert DSC certificates
         final var dscTrustLists = dgcClient.download(CertificateType.DSC);
         final var dbDscList = new ArrayList<DbDsc>();
@@ -188,6 +190,10 @@ public class DGCSyncer {
             }
         }
         return false;
+    }
+
+    private Date nowPlus1Min() {
+        return Date.from(OffsetDateTime.now().plusMinutes(1).toInstant());
     }
 
     private void upload() {

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/WsBaseConfig.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/WsBaseConfig.java
@@ -48,110 +48,111 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public abstract class WsBaseConfig implements WebMvcConfigurer {
 
-  protected final Logger logger = LoggerFactory.getLogger(getClass());
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
 
-  @Value("${ws.jws.p12:}")
-  public String p12KeyStore;
+    @Value("${ws.jws.p12:}")
+    public String p12KeyStore;
 
-  @Value("${ws.jws.password:}")
-  public String p12KeyStorePassword;
+    @Value("${ws.jws.password:}")
+    public String p12KeyStorePassword;
 
-  @Value(
-      "#{${ws.security.headers: {'X-Content-Type-Options':'nosniff', 'X-Frame-Options':'DENY','X-Xss-Protection':'1; mode=block'}}}")
-  Map<String, String> additionalHeaders;
+    @Value(
+            "#{${ws.security.headers: {'X-Content-Type-Options':'nosniff', 'X-Frame-Options':'DENY','X-Xss-Protection':'1; mode=block'}}}")
+    Map<String, String> additionalHeaders;
 
-  @Value("${revocationList.baseurl}")
-  String revokedCertsBaseUrl;
+    @Value("${revocationList.baseurl}")
+    String revokedCertsBaseUrl;
 
-  public abstract DataSource dataSource();
+    public abstract DataSource dataSource();
 
-  public abstract Flyway flyway();
+    public abstract Flyway flyway();
 
-  @Value("${ws.keys.release-bucket-duration:PT1H}")
-  public void setKeysBucketDuration(Duration bucketDuration) {
-    CacheUtil.KEYS_BUCKET_DURATION = bucketDuration;
-  }
-
-  @Value("${ws.revocationList.max-age:PT1M}")
-  public void setRevocationListMaxAge(Duration maxAge) {
-    CacheUtil.REVOCATION_LIST_MAX_AGE = maxAge;
-  }
-
-  @Value("${ws.verificationRules.max-age:PT1M}")
-  public void setVerificationRulesMaxAge(Duration maxAge) {
-    CacheUtil.VERIFICATION_RULES_MAX_AGE = maxAge;
-  }
-
-  @Value("${ws.valueSets.max-age:PT1M}")
-  public void setValueSetsMaxAge(Duration maxAge) {
-    CacheUtil.VALUE_SETS_MAX_AGE = maxAge;
-  }
-
-  @Override
-  public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
-    try {
-      converters.add(new JwsMessageConverter(jwsKeyStore(), p12KeyStorePassword.toCharArray()));
-    } catch (KeyStoreException
-        | NoSuchAlgorithmException
-        | CertificateException
-        | IOException
-        | UnrecoverableKeyException e) {
-      logger.error("Could not load key store", e);
-      throw new RuntimeException("Could not add jws Converter");
+    @Value("${ws.keys.release-bucket-duration:PT1H}")
+    public void setKeysBucketDuration(Duration bucketDuration) {
+        CacheUtil.KEYS_BUCKET_DURATION = bucketDuration;
     }
-  }
 
-  public KeyStore jwsKeyStore()
-      throws KeyStoreException, NoSuchAlgorithmException, CertificateException, IOException {
-    var keyStore = KeyStore.getInstance("pkcs12");
-    var bais = new ByteArrayInputStream(Base64.getDecoder().decode(p12KeyStore));
-    keyStore.load(bais, p12KeyStorePassword.toCharArray());
-    return keyStore;
-  }
+    @Value("${ws.revocationList.max-age:PT1M}")
+    public void setRevocationListMaxAge(Duration maxAge) {
+        CacheUtil.REVOCATION_LIST_MAX_AGE = maxAge;
+    }
 
-  @Bean
-  public HeaderInjector securityHeaderInjector() {
-    return new HeaderInjector(additionalHeaders);
-  }
+    @Value("${ws.verificationRules.max-age:PT1M}")
+    public void setVerificationRulesMaxAge(Duration maxAge) {
+        CacheUtil.VERIFICATION_RULES_MAX_AGE = maxAge;
+    }
 
-  @Override
-  public void addInterceptors(InterceptorRegistry registry) {
-    registry.addInterceptor(securityHeaderInjector());
-  }
+    @Value("${ws.valueSets.max-age:PT1M}")
+    public void setValueSetsMaxAge(Duration maxAge) {
+        CacheUtil.VALUE_SETS_MAX_AGE = maxAge;
+    }
 
-  @Bean
-  public VerifierDataService verifierDataService(DataSource dataSource) {
-    return new JdbcVerifierDataServiceImpl(dataSource);
-  }
+    @Override
+    public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
+        try {
+            converters.add(
+                    new JwsMessageConverter(jwsKeyStore(), p12KeyStorePassword.toCharArray()));
+        } catch (KeyStoreException
+                | NoSuchAlgorithmException
+                | CertificateException
+                | IOException
+                | UnrecoverableKeyException e) {
+            logger.error("Could not load key store", e);
+            throw new RuntimeException("Could not add jws Converter");
+        }
+    }
 
-  @Bean
-  public AppTokenDataService appTokenDataService(DataSource dataSource) {
-    return new JdbcAppTokenDataServiceImpl(dataSource);
-  }
+    public KeyStore jwsKeyStore()
+            throws KeyStoreException, NoSuchAlgorithmException, CertificateException, IOException {
+        var keyStore = KeyStore.getInstance("pkcs12");
+        var bais = new ByteArrayInputStream(Base64.getDecoder().decode(p12KeyStore));
+        keyStore.load(bais, p12KeyStorePassword.toCharArray());
+        return keyStore;
+    }
 
-  @Bean
-  public KeyController keyController(VerifierDataService verifierDataService) {
-    return new KeyController(verifierDataService);
-  }
+    @Bean
+    public HeaderInjector securityHeaderInjector() {
+        return new HeaderInjector(additionalHeaders);
+    }
 
-  @Bean
-  public RevocationListController revocationListController() {
-    return new RevocationListController(revokedCertsBaseUrl);
-  }
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(securityHeaderInjector());
+    }
 
-  @Bean
-  public VerificationRulesController verificationRulesController()
-      throws IOException, NoSuchAlgorithmException {
-    return new VerificationRulesController();
-  }
+    @Bean
+    public VerifierDataService verifierDataService(DataSource dataSource) {
+        return new JdbcVerifierDataServiceImpl(dataSource);
+    }
 
-  @Bean
-  public ValueSetsController valueSetsController() throws IOException, NoSuchAlgorithmException {
-    return new ValueSetsController();
-  }
+    @Bean
+    public AppTokenDataService appTokenDataService(DataSource dataSource) {
+        return new JdbcAppTokenDataServiceImpl(dataSource);
+    }
 
-  @Bean
-  public RestTemplate restTemplate() {
-    return RestTemplateHelper.getRestTemplate();
-  }
+    @Bean
+    public KeyController keyController(VerifierDataService verifierDataService) {
+        return new KeyController(verifierDataService);
+    }
+
+    @Bean
+    public RevocationListController revocationListController() {
+        return new RevocationListController(revokedCertsBaseUrl);
+    }
+
+    @Bean
+    public VerificationRulesController verificationRulesController()
+            throws IOException, NoSuchAlgorithmException {
+        return new VerificationRulesController();
+    }
+
+    @Bean
+    public ValueSetsController valueSetsController() throws IOException, NoSuchAlgorithmException {
+        return new ValueSetsController();
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return RestTemplateHelper.getRestTemplate();
+    }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/KeyController.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/KeyController.java
@@ -18,8 +18,9 @@ import ch.admin.bag.covidcertificate.backend.verifier.model.cert.ClientCert;
 import ch.admin.bag.covidcertificate.backend.verifier.ws.utils.CacheUtil;
 import ch.admin.bag.covidcertificate.backend.verifier.ws.utils.EtagUtil;
 import ch.ubique.openapi.docannotations.Documentation;
+import java.sql.Date;
+import java.time.OffsetDateTime;
 import java.util.List;
-import org.springframework.http.CacheControl;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -35,79 +36,90 @@ import org.springframework.web.context.request.WebRequest;
 @RequestMapping("trust/v1/keys")
 public class KeyController {
 
-    private static final String NEXT_SINCE_HEADER = "X-Next-Since";
-    private static final String UP_TO_DATE_HEADER = "up-to-date";
-    private final VerifierDataService verifierDataService;
+  private static final String NEXT_SINCE_HEADER = "X-Next-Since";
+  private static final String UP_TO_DATE_HEADER = "up-to-date";
+  private final VerifierDataService verifierDataService;
 
-    public KeyController(VerifierDataService verifierDataService) {
-        this.verifierDataService = verifierDataService;
+  public KeyController(VerifierDataService verifierDataService) {
+    this.verifierDataService = verifierDataService;
+  }
+
+  @Documentation(
+      description = "Echo endpoint",
+      responses = {"200 => Hello from CH Covidcertificate Verifier WS"})
+  @CrossOrigin(origins = {"https://editor.swagger.io"})
+  @GetMapping(value = "")
+  public @ResponseBody String hello() {
+    return "Hello from CH Covidcertificate Verifier WS";
+  }
+
+  @Documentation(
+      description = "get signer certificates",
+      responses = {
+        "200 => next certificate batch after `since`. keep requesting until empty certs list is returned"
+      },
+      responseHeaders = {
+        "X-Next-Since:`since` to set for next request:string",
+        "up-to-date:set to 'true' when no more certs to fetch:string"
+      })
+  @CrossOrigin(origins = {"https://editor.swagger.io"})
+  @GetMapping(value = "updates")
+  public @ResponseBody ResponseEntity<CertsResponse> getSignerCerts(
+      @RequestParam(required = false, defaultValue = "0") Long since,
+      @RequestParam CertFormat certFormat) {
+    OffsetDateTime nextBucketRelease = CacheUtil.roundToNextBucket(OffsetDateTime.now());
+    OffsetDateTime previousBucketRelease =
+        nextBucketRelease.minus(CacheUtil.KEYS_BUCKET_DURATION).minusMinutes(10);
+
+    List<ClientCert> dscs =
+        verifierDataService.findDSCs(
+            since, certFormat, Date.from(previousBucketRelease.toInstant()));
+    return ResponseEntity.ok()
+        .headers(getKeysUpdatesHeaders(dscs))
+        .headers(CacheUtil.createExpiresHeader(nextBucketRelease))
+        .body(new CertsResponse(dscs));
+  }
+
+  private HttpHeaders getKeysUpdatesHeaders(List<ClientCert> dscs) {
+    HttpHeaders headers = new HttpHeaders();
+    Long nextSince =
+        dscs.stream()
+            .mapToLong(dsc -> dsc.getPkId())
+            .max()
+            .orElse(verifierDataService.findMaxDSCPkId());
+    headers.add(NEXT_SINCE_HEADER, nextSince.toString());
+    if (dscs.size() < verifierDataService.getMaxDSCBatchCount()) {
+      headers.add(UP_TO_DATE_HEADER, "true");
+    }
+    return headers;
+  }
+
+  @Documentation(
+      description = "get all key IDs of active signer certs",
+      responses = {
+        "200 => list of Key IDs of all active signer certs",
+        "304 => no changes since last request"
+      },
+      responseHeaders = {"ETag:etag to set for next request:string"})
+  @CrossOrigin(origins = {"https://editor.swagger.io"})
+  @GetMapping(value = "list")
+  public @ResponseBody ResponseEntity<ActiveCertsResponse> getActiveSignerCertKeyIds(
+      WebRequest request) {
+    OffsetDateTime nextBucketRelease =
+        CacheUtil.roundToNextBucket(OffsetDateTime.now().plusMinutes(10)).minusMinutes(10);
+    OffsetDateTime previousBucketRelease = nextBucketRelease.minus(CacheUtil.KEYS_BUCKET_DURATION);
+
+    List<String> activeKeyIds =
+        verifierDataService.findActiveDSCKeyIds(Date.from(previousBucketRelease.toInstant()));
+
+    // check etag
+    String currentEtag = String.valueOf(EtagUtil.getUnsortedListHashcode(activeKeyIds));
+    if (request.checkNotModified(currentEtag)) {
+      return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build();
     }
 
-    @Documentation(
-            description = "Echo endpoint",
-            responses = {"200 => Hello from CH Covidcertificate Verifier WS"})
-    @CrossOrigin(origins = {"https://editor.swagger.io"})
-    @GetMapping(value = "")
-    public @ResponseBody String hello() {
-        return "Hello from CH Covidcertificate Verifier WS";
-    }
-
-    @Documentation(
-            description = "get signer certificates",
-            responses = {
-                "200 => next certificate batch after `since`. keep requesting until empty certs list is returned"
-            },
-            responseHeaders = {
-                "X-Next-Since:`since` to set for next request:string",
-                "up-to-date:set to 'true' when no more certs to fetch:string"
-            })
-    @CrossOrigin(origins = {"https://editor.swagger.io"})
-    @GetMapping(value = "updates")
-    public @ResponseBody ResponseEntity<CertsResponse> getSignerCerts(
-            @RequestParam(required = false, defaultValue = "0") Long since,
-            @RequestParam CertFormat certFormat) {
-        List<ClientCert> dscs = verifierDataService.findDSCs(since, certFormat);
-        return ResponseEntity.ok()
-                .headers(getKeysUpdatesHeaders(dscs))
-                .cacheControl(CacheControl.maxAge(CacheUtil.KEYS_UPDATE_MAX_AGE))
-                .body(new CertsResponse(dscs));
-    }
-
-    private HttpHeaders getKeysUpdatesHeaders(List<ClientCert> dscs) {
-        HttpHeaders headers = new HttpHeaders();
-        Long nextSince =
-                dscs.stream()
-                        .mapToLong(dsc -> dsc.getPkId())
-                        .max()
-                        .orElse(verifierDataService.findMaxDSCPkId());
-        headers.add(NEXT_SINCE_HEADER, nextSince.toString());
-        if (dscs.size() < verifierDataService.getMaxDSCBatchCount()) {
-            headers.add(UP_TO_DATE_HEADER, "true");
-        }
-        return headers;
-    }
-
-    @Documentation(
-            description = "get all key IDs of active signer certs",
-            responses = {
-                "200 => list of Key IDs of all active signer certs",
-                "304 => no changes since last request"
-            },
-            responseHeaders = {"ETag:etag to set for next request:string"})
-    @CrossOrigin(origins = {"https://editor.swagger.io"})
-    @GetMapping(value = "list")
-    public @ResponseBody ResponseEntity<ActiveCertsResponse> getActiveSignerCertKeyIds(
-            WebRequest request) {
-        List<String> activeKeyIds = verifierDataService.findActiveDSCKeyIds();
-
-        // check etag
-        String currentEtag = String.valueOf(EtagUtil.getUnsortedListHashcode(activeKeyIds));
-        if (request.checkNotModified(currentEtag)) {
-            return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build();
-        }
-
-        return ResponseEntity.ok()
-                .cacheControl(CacheControl.maxAge(CacheUtil.KEYS_LIST_MAX_AGE))
-                .body(new ActiveCertsResponse(activeKeyIds));
-    }
+    return ResponseEntity.ok()
+        .headers(CacheUtil.createExpiresHeader(nextBucketRelease))
+        .body(new ActiveCertsResponse(activeKeyIds));
+  }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/utils/CacheUtil.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/utils/CacheUtil.java
@@ -10,45 +10,45 @@ import java.util.TimeZone;
 import org.springframework.http.HttpHeaders;
 
 public class CacheUtil {
-  public static Duration REVOCATION_LIST_MAX_AGE;
-  public static Duration VERIFICATION_RULES_MAX_AGE;
-  public static Duration VALUE_SETS_MAX_AGE;
-  public static Duration KEYS_BUCKET_DURATION;
+    public static Duration REVOCATION_LIST_MAX_AGE;
+    public static Duration VERIFICATION_RULES_MAX_AGE;
+    public static Duration VALUE_SETS_MAX_AGE;
+    public static Duration KEYS_BUCKET_DURATION;
 
-  private CacheUtil() {}
+    private CacheUtil() {}
 
-  /**
-   * Formats the date to a http timestamp.
-   *
-   * @param date
-   * @return
-   */
-  private static String formatHeaderDate(OffsetDateTime date) {
-    SimpleDateFormat sdf = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.US);
-    sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
-    return sdf.format(date);
-  }
+    /**
+     * Formats the date to a http timestamp.
+     *
+     * @param date
+     * @return
+     */
+    private static String formatHeaderDate(OffsetDateTime date) {
+        SimpleDateFormat sdf = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.US);
+        sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+        return sdf.format(date);
+    }
 
-  public static HttpHeaders createExpiresHeader(OffsetDateTime expires) {
-    HttpHeaders headers = new HttpHeaders();
-    headers.set("Expires", formatHeaderDate(expires));
-    return headers;
-  }
+    public static HttpHeaders createExpiresHeader(OffsetDateTime expires) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Expires", formatHeaderDate(expires));
+        return headers;
+    }
 
-  /**
-   * @param now
-   * @param releaseBucketDuration
-   * @return the start of the next bucket. If the `now` is at the beginning of a bucket, the next
-   *     bucket will be returned.
-   */
-  public static OffsetDateTime roundToNextBucket(
-      OffsetDateTime now, Duration releaseBucketDuration) {
-    long rounding = releaseBucketDuration.toMillis();
-    long timestamp = ((now.toInstant().toEpochMilli() / rounding) + 1) * rounding;
-    return OffsetDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneOffset.UTC);
-  }
+    /**
+     * @param now
+     * @param releaseBucketDuration
+     * @return the start of the next bucket. If the `now` is at the beginning of a bucket, the next
+     *     bucket will be returned.
+     */
+    public static OffsetDateTime roundToNextBucket(
+            OffsetDateTime now, Duration releaseBucketDuration) {
+        long rounding = releaseBucketDuration.toMillis();
+        long timestamp = ((now.toInstant().toEpochMilli() / rounding) + 1) * rounding;
+        return OffsetDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneOffset.UTC);
+    }
 
-  public static OffsetDateTime roundToNextBucket(OffsetDateTime now) {
-    return roundToNextBucket(now, CacheUtil.KEYS_BUCKET_DURATION);
-  }
+    public static OffsetDateTime roundToNextBucket(OffsetDateTime now) {
+        return roundToNextBucket(now, CacheUtil.KEYS_BUCKET_DURATION);
+    }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/utils/CacheUtil.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/utils/CacheUtil.java
@@ -1,12 +1,12 @@
 package ch.admin.bag.covidcertificate.backend.verifier.ws.utils;
 
-import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Locale;
-import java.util.TimeZone;
 import org.springframework.http.HttpHeaders;
 
 public class CacheUtil {
@@ -24,9 +24,11 @@ public class CacheUtil {
      * @return
      */
     private static String formatHeaderDate(OffsetDateTime date) {
-        SimpleDateFormat sdf = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.US);
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
-        return sdf.format(date);
+        DateTimeFormatter formatter =
+                DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss z")
+                        .withLocale(Locale.US)
+                        .withZone(ZoneId.of("GMT"));
+        return formatter.format(date);
     }
 
     public static HttpHeaders createExpiresHeader(OffsetDateTime expires) {

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/utils/CacheUtil.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/utils/CacheUtil.java
@@ -1,13 +1,54 @@
 package ch.admin.bag.covidcertificate.backend.verifier.ws.utils;
 
+import java.text.SimpleDateFormat;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Locale;
+import java.util.TimeZone;
+import org.springframework.http.HttpHeaders;
 
 public class CacheUtil {
-    public static Duration REVOCATION_LIST_MAX_AGE;
-    public static Duration VERIFICATION_RULES_MAX_AGE;
-    public static Duration VALUE_SETS_MAX_AGE;
-    public static Duration KEYS_UPDATE_MAX_AGE;
-    public static Duration KEYS_LIST_MAX_AGE;
+  public static Duration REVOCATION_LIST_MAX_AGE;
+  public static Duration VERIFICATION_RULES_MAX_AGE;
+  public static Duration VALUE_SETS_MAX_AGE;
+  public static Duration KEYS_BUCKET_DURATION;
 
-    private CacheUtil() {}
+  private CacheUtil() {}
+
+  /**
+   * Formats the date to a http timestamp.
+   *
+   * @param date
+   * @return
+   */
+  private static String formatHeaderDate(OffsetDateTime date) {
+    SimpleDateFormat sdf = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.US);
+    sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+    return sdf.format(date);
+  }
+
+  public static HttpHeaders createExpiresHeader(OffsetDateTime expires) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Expires", formatHeaderDate(expires));
+    return headers;
+  }
+
+  /**
+   * @param now
+   * @param releaseBucketDuration
+   * @return the start of the next bucket. If the `now` is at the beginning of a bucket, the next
+   *     bucket will be returned.
+   */
+  public static OffsetDateTime roundToNextBucket(
+      OffsetDateTime now, Duration releaseBucketDuration) {
+    long rounding = releaseBucketDuration.toMillis();
+    long timestamp = ((now.toInstant().toEpochMilli() / rounding) + 1) * rounding;
+    return OffsetDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneOffset.UTC);
+  }
+
+  public static OffsetDateTime roundToNextBucket(OffsetDateTime now) {
+    return roundToNextBucket(now, CacheUtil.KEYS_BUCKET_DURATION);
+  }
 }


### PR DESCRIPTION
This solves problems with CDN cache synchronization, as /keys/updates
and /keys/list are requested independently by the clients but need to
be synchronised to make sure clients do not download new keys (and
therefore store new NEXT_SINCE_HEADER) but then directly delete them
again since they are not yet in the /keys/list.

By releasing them only once per hour, moving from Cache-Control
(relative time) to using Expiry (absolute time) and releasing new keys
to /keys/list 10min earlier than /keys/updates, clients should not run
into this problem anymore.