### PR TITLE
ensure manually added certificates are not removed by sync

### DIFF
--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/VerifierDataService.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/VerifierDataService.java
@@ -23,7 +23,7 @@ public interface VerifierDataService {
     public void insertCSCAs(List<DbCsca> cscas);
 
     /**
-     * removes all csas with key ids in the given list
+     * removes all csas with key ids in the given list that haven't been added manually
      *
      * @param keyIds
      * @return number of removed CSCAs
@@ -44,10 +44,10 @@ public interface VerifierDataService {
     /** inserts the given DSC into the db */
     public void insertDSCs(List<DbDsc> dsc);
 
-    /** removes all DSCs with key ids not in the given list */
+    /** removes all DSCs with key ids not in the given list that haven't been added manually */
     public int removeDSCsNotIn(List<String> keyIdsToKeep);
 
-    /** removes all DSCs signed by a CSCA in the given list */
+    /** removes all DSCs signed by a CSCA in the given list that haven't been added manually */
     public int removeDSCsWithCSCAIn(List<String> cscaKidsToRemove);
 
     /**

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/resources/db/migration/pgsql/V0_4__certificate_source.sql
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/resources/db/migration/pgsql/V0_4__certificate_source.sql
@@ -1,0 +1,15 @@
+/*
+ * Created by Ubique Innovation AG
+ * https://www.ubique.ch
+ * Copyright (c) 2021. All rights reserved.
+ */
+
+alter table t_country_specific_certificate_authority add column source character varying(10);
+update t_country_specific_certificate_authority set source = 'SYNC';
+alter table t_country_specific_certificate_authority alter column source set not null;
+update t_country_specific_certificate_authority set source = 'MANUAL' where origin = 'CH';
+
+alter table t_document_signer_certificate add column source character varying(10);
+update t_document_signer_certificate set source = 'SYNC';
+alter table t_document_signer_certificate alter column source set not null;
+update t_document_signer_certificate set source = 'MANUAL' where origin = 'CH';

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/resources/db/migration/pgsql_cluster/V0_4__certificate_source.sql
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/resources/db/migration/pgsql_cluster/V0_4__certificate_source.sql
@@ -1,0 +1,15 @@
+/*
+ * Created by Ubique Innovation AG
+ * https://www.ubique.ch
+ * Copyright (c) 2021. All rights reserved.
+ */
+
+alter table t_country_specific_certificate_authority add column source character varying(10);
+update t_country_specific_certificate_authority set source = 'SYNC';
+alter table t_country_specific_certificate_authority alter column source set not null;
+update t_country_specific_certificate_authority set source = 'MANUAL' where origin = 'CH';
+
+alter table t_document_signer_certificate add column source character varying(10);
+update t_document_signer_certificate set source = 'SYNC';
+alter table t_document_signer_certificate alter column source set not null;
+update t_document_signer_certificate set source = 'MANUAL' where origin = 'CH';

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/data/BaseDataServiceTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/data/BaseDataServiceTest.java
@@ -2,11 +2,16 @@ package ch.admin.bag.covidcertificate.backend.verifier.data;
 
 import ch.admin.bag.covidcertificate.backend.verifier.data.config.FlywayConfig;
 import ch.admin.bag.covidcertificate.backend.verifier.data.config.TestConfig;
+import javax.sql.DataSource;
 import javax.validation.constraints.NotNull;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.context.annotation.ComponentScan;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
@@ -20,6 +25,7 @@ import org.testcontainers.utility.DockerImageName;
 @ContextConfiguration(initializers = BaseDataServiceTest.DockerPostgresDataSourceInitializer.class)
 @SpringBootTest(classes = {TestConfig.class, FlywayConfig.class})
 @Testcontainers
+@TestInstance(Lifecycle.PER_CLASS)
 public abstract class BaseDataServiceTest {
 
     public static PostgreSQLContainer<?> postgreSQLContainer =
@@ -43,5 +49,13 @@ public abstract class BaseDataServiceTest {
                     "spring.datasource.username=" + postgreSQLContainer.getUsername(),
                     "spring.datasource.password=" + postgreSQLContainer.getPassword());
         }
+    }
+
+    @Autowired DataSource dataSource;
+    protected NamedParameterJdbcTemplate jt;
+
+    @BeforeAll
+    void setup() {
+        this.jt = new NamedParameterJdbcTemplate(dataSource);
     }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-model/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/model/CertSource.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-model/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/model/CertSource.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2021 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package ch.admin.bag.covidcertificate.backend.verifier.model;
+
+public enum CertSource {
+    MANUAL,
+    SYNC;
+}

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-model/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/model/cert/ClientCert.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-model/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/model/cert/ClientCert.java
@@ -12,7 +12,7 @@ public class ClientCert {
 
     @Documentation(
             description =
-                    "either 'sig' (all) or one or more of: 'r' (recovery), 't' (test), 'v' (vaccine)",
+                    "either 'sig' (all) or one or more of: 'r' (recovery), 't' (test), 'v' (vaccine), 'l' (light)",
             example = "sig")
     private String use;
 


### PR DESCRIPTION
this pull request adds a source field to the csca and dsc tables which is used to differentiate between manually added certificates and certificates received via sync. this is needed for adding certificates that are not exchanged with the dgc hub.