### PR TITLE
fix normalizeEcCurvePoint for byte arrays with length < 32

### DIFF
--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-sync/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/sync/utils/TrustListMapper.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-sync/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/sync/utils/TrustListMapper.java
@@ -168,7 +168,7 @@ public class TrustListMapper {
         if (array.length == 33) {
             System.arraycopy(array, 1, unsignedArr, 0, byteArrayLength);
         } else {
-            System.arraycopy(array, 0, unsignedArr, 0, byteArrayLength);
+            System.arraycopy(array, 0, array.length, byteArrayLength - array.length, array.length);
         }
 
         return Base64.getEncoder().encodeToString(unsignedArr);


### PR DESCRIPTION
this pull request fixes ec curve point normalization for byte arrays that have a length < 32