### PR TITLE
Update national rules

### DIFF
--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/verificationRules.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/verificationRules.json
@@ -195,10 +195,10 @@
       "logic": {
         "if": [
           {
-            "var": "payload.v.0"
-          },
-          {
-            "if": [
+            "and": [
+              {
+                "var": "payload.v.0"
+              },
               {
                 "in": [
                   {
@@ -210,30 +210,37 @@
                 ]
               },
               {
-                ">=": [
+                "==": [
                   {
-                    "plusTime": [
-                      {
-                        "var": "external.validationClockAtStartOfDay"
-                      },
-                      0,
-                      "day"
-                    ]
+                    "var": "payload.v.0.dn"
                   },
+                  1
+                ]
+              }
+            ]
+          },
+          {
+            ">=": [
+              {
+                "plusTime": [
                   {
-                    "plusTime": [
-                      {
-                        "var": "payload.v.0.dt"
-                      },
-                      {
-                        "var": "external.valueSets.acceptance-criteria.single-vaccine-validity-offset"
-                      },
-                      "day"
-                    ]
-                  }
+                    "var": "external.validationClockAtStartOfDay"
+                  },
+                  0,
+                  "day"
                 ]
               },
-              true
+              {
+                "plusTime": [
+                  {
+                    "var": "payload.v.0.dt"
+                  },
+                  {
+                    "var": "external.valueSets.acceptance-criteria.single-vaccine-validity-offset"
+                  },
+                  "day"
+                ]
+              }
             ]
           },
           true
@@ -268,6 +275,63 @@
                   {
                     "var": "external.valueSets.acceptance-criteria.vaccine-immunity"
                   },
+                  "day"
+                ]
+              }
+            ]
+          },
+          true
+        ]
+      }
+    },
+    {
+      "id": "VR-CH-0007",
+      "description": "If the vaccine requires only one dose but more than one dose was administered, it is valid from today ",
+      "inputParameter": "Vaccination Part of the HCert (\"v\") + Valuesets",
+      "logic": {
+        "if": [
+          {
+            "and": [
+              {
+                "var": "payload.v.0"
+              },
+              {
+                "in": [
+                  {
+                    "var": "payload.v.0.mp"
+                  },
+                  {
+                    "var": "external.valueSets.one-dose-vaccines-with-offset"
+                  }
+                ]
+              },
+              {
+                ">": [
+                  {
+                    "var": "payload.v.0.dn"
+                  },
+                  1
+                ]
+              }
+            ]
+          },
+          {
+            ">=": [
+              {
+                "plusTime": [
+                  {
+                    "var": "external.validationClockAtStartOfDay"
+                  },
+                  0,
+                  "day"
+                ]
+              },
+              {
+                "plusTime": [
+                  {
+                    "var": "payload.v.0.dt"
+                  },
+                  0,
                   "day"
                 ]
               }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/verificationRules.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/verificationRules.json
@@ -156,7 +156,7 @@
                     "var": "payload.v.0.mp"
                   },
                   {
-                    "var": "external.valueSets.two-doses-vaccines"
+                    "var": "external.valueSets.two-dose-vaccines"
                   }
                 ]
               }
@@ -209,7 +209,7 @@
                         "var": "payload.v.0.mp"
                       },
                       {
-                        "var": "external.valueSets.one-dose-vaccines"
+                        "var": "external.valueSets.one-dose-vaccines-with-offset"
                       }
                     ]
                   },
@@ -310,7 +310,7 @@
                         "var": "payload.v.0.mp"
                       },
                       {
-                        "var": "external.valueSets.one-dose-vaccines"
+                        "var": "external.valueSets.one-dose-vaccines-with-offset"
                       }
                     ]
                   },
@@ -658,12 +658,12 @@
       "EU/1/21/1529",
       "EU/1/20/1525"
     ],
-    "two-doses-vaccines": [
+    "two-dose-vaccines": [
       "EU/1/20/1528",
       "EU/1/20/1507",
       "EU/1/21/1529"
     ],
-    "one-dose-vaccines": [
+    "one-dose-vaccines-with-offset": [
       "EU/1/20/1525"
     ],
     "covid-19-lab-test-type": [

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/verificationRules.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/verificationRules.json
@@ -210,7 +210,7 @@
                 ]
               },
               {
-                "==": [
+                "===": [
                   {
                     "var": "payload.v.0.dn"
                   },
@@ -291,50 +291,55 @@
       "logic": {
         "if": [
           {
-            "and": [
+            "var": "payload.v.0"
+          },
+          {
+            "if": [
               {
-                "var": "payload.v.0"
-              },
-              {
-                "in": [
+                "and": [
                   {
-                    "var": "payload.v.0.mp"
+                    "in": [
+                      {
+                        "var": "payload.v.0.mp"
+                      },
+                      {
+                        "var": "external.valueSets.one-dose-vaccines-with-offset"
+                      }
+                    ]
                   },
                   {
-                    "var": "external.valueSets.one-dose-vaccines-with-offset"
+                    ">": [
+                      {
+                        "var": "payload.v.0.dn"
+                      },
+                      1
+                    ]
                   }
                 ]
               },
               {
-                ">": [
+                ">=": [
                   {
-                    "var": "payload.v.0.dn"
+                    "plusTime": [
+                      {
+                        "var": "external.validationClockAtStartOfDay"
+                      },
+                      0,
+                      "day"
+                    ]
                   },
-                  1
-                ]
-              }
-            ]
-          },
-          {
-            ">=": [
-              {
-                "plusTime": [
                   {
-                    "var": "external.validationClockAtStartOfDay"
-                  },
-                  0,
-                  "day"
+                    "plusTime": [
+                      {
+                        "var": "payload.v.0.dt"
+                      },
+                      0,
+                      "day"
+                    ]
+                  }
                 ]
               },
-              {
-                "plusTime": [
-                  {
-                    "var": "payload.v.0.dt"
-                  },
-                  0,
-                  "day"
-                ]
-              }
+              true
             ]
           },
           true

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/verificationRules.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/verificationRules.json
@@ -156,7 +156,7 @@
                     "var": "payload.v.0.mp"
                   },
                   {
-                    "var": "external.valueSets.two-dose-vaccines"
+                    "var": "external.valueSets.two-doses-vaccines"
                   }
                 ]
               }
@@ -178,7 +178,9 @@
                   {
                     "var": "payload.v.0.dt"
                   },
-                  0,
+                  {
+                    "var": "external.valueSets.acceptance-criteria.two-doses-vaccine-validity-offset"
+                  },
                   "day"
                 ]
               }
@@ -194,59 +196,59 @@
       "inputParameter": "Vaccination Part of the HCert (\"v\") + Valuesets",
       "logic": {
         "if": [
-              {
-                "var": "payload.v.0"
-              },
+          {
+            "var": "payload.v.0"
+          },
           {
             "if": [
               {
                 "and": [
-              {
-                "in": [
                   {
-                    "var": "payload.v.0.mp"
+                    "in": [
+                      {
+                        "var": "payload.v.0.mp"
+                      },
+                      {
+                        "var": "external.valueSets.one-dose-vaccines"
+                      }
+                    ]
                   },
                   {
-                    "var": "external.valueSets.one-dose-vaccines-with-offset"
+                    "===": [
+                      {
+                        "var": "payload.v.0.dn"
+                      },
+                      1
+                    ]
                   }
                 ]
               },
               {
-                "===": [
+                ">=": [
                   {
-                    "var": "payload.v.0.dn"
+                    "plusTime": [
+                      {
+                        "var": "external.validationClockAtStartOfDay"
+                      },
+                      0,
+                      "day"
+                    ]
                   },
-                  1
-                ]
-              }
-            ]
-          },
-          {
-            ">=": [
-              {
-                "plusTime": [
                   {
-                    "var": "external.validationClockAtStartOfDay"
-                  },
-                  0,
-                  "day"
+                    "plusTime": [
+                      {
+                        "var": "payload.v.0.dt"
+                      },
+                      {
+                        "var": "external.valueSets.acceptance-criteria.single-vaccine-validity-offset"
+                      },
+                      "day"
+                    ]
+                  }
                 ]
               },
-              {
-                "plusTime": [
-                  {
-                    "var": "payload.v.0.dt"
-                  },
-                  {
-                    "var": "external.valueSets.acceptance-criteria.single-vaccine-validity-offset"
-                  },
-                  "day"
-                ]
-              }
+              true
             ]
-          },
-          true
-        ]
           },
           true
         ]
@@ -308,7 +310,7 @@
                         "var": "payload.v.0.mp"
                       },
                       {
-                        "var": "external.valueSets.one-dose-vaccines-with-offset"
+                        "var": "external.valueSets.one-dose-vaccines"
                       }
                     ]
                   },
@@ -656,12 +658,12 @@
       "EU/1/21/1529",
       "EU/1/20/1525"
     ],
-    "two-dose-vaccines": [
+    "two-doses-vaccines": [
       "EU/1/20/1528",
       "EU/1/20/1507",
       "EU/1/21/1529"
     ],
-    "one-dose-vaccines-with-offset": [
+    "one-dose-vaccines": [
       "EU/1/20/1525"
     ],
     "covid-19-lab-test-type": [
@@ -670,6 +672,7 @@
     ],
     "acceptance-criteria": {
       "single-vaccine-validity-offset": 21,
+      "two-doses-vaccine-validity-offset": 0,
       "vaccine-immunity": 364,
       "rat-test-validity": 48,
       "pcr-test-validity": 72,

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/verificationRules.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/verificationRules.json
@@ -194,11 +194,13 @@
       "inputParameter": "Vaccination Part of the HCert (\"v\") + Valuesets",
       "logic": {
         "if": [
-          {
-            "and": [
               {
                 "var": "payload.v.0"
               },
+          {
+            "if": [
+              {
+                "and": [
               {
                 "in": [
                   {
@@ -242,6 +244,9 @@
                 ]
               }
             ]
+          },
+          true
+        ]
           },
           true
         ]

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/verificationRules.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/verificationRules.json
@@ -335,35 +335,6 @@
       }
     },
     {
-      "id": "TR-CH-0003",
-      "businessDescription": "If the test type is \"RAT\" then the test must be in the list of accepted RAT tests.",
-      "description": "If the test type is \"RAT\" then the \"test product and manufacturer\" MUST be in the valueset list, if it's NAA return true.",
-      "inputParameter": "Test Part of the HCert (\"t\")+ Valuesets +\"tt\" + \"ma\"",
-      "logic": {
-        "if": [
-          {
-            "===": [
-              {
-                "var": "payload.t.0.tt"
-              },
-              "LP217198-3"
-            ]
-          },
-          {
-            "in": [
-              {
-                "var": "payload.t.0.ma"
-              },
-              {
-                "var": "external.valueSets.covid-19-lab-test-manufacturer-and-name"
-              }
-            ]
-          },
-          true
-        ]
-      }
-    },
-    {
       "id": "TR-CH-0004",
       "description": "Date of sample collection must exist",
       "inputParameter": "Entire HCert JSON (\"t\")",
@@ -622,96 +593,6 @@
     "covid-19-lab-test-type": [
       "LP217198-3",
       "LP6464-4"
-    ],
-    "covid-19-lab-test-manufacturer-and-name": [
-      "308",
-      "344",
-      "345",
-      "768",
-      "1065",
-      "1097",
-      "1114",
-      "1144",
-      "1162",
-      "1173",
-      "1180",
-      "1190",
-      "1199",
-      "1201",
-      "1215",
-      "1218",
-      "1223",
-      "1225",
-      "1232",
-      "1236",
-      "1242",
-      "1244",
-      "1253",
-      "1257",
-      "1263",
-      "1266",
-      "1267",
-      "1268",
-      "1271",
-      "1278",
-      "1295",
-      "1296",
-      "1304",
-      "1319",
-      "1331",
-      "1333",
-      "1341",
-      "1343",
-      "1360",
-      "1363",
-      "1365",
-      "1375",
-      "1392",
-      "1420",
-      "1437",
-      "1443",
-      "1456",
-      "1466",
-      "1468",
-      "1481",
-      "1484",
-      "1489",
-      "1490",
-      "1501",
-      "1574",
-      "1604",
-      "1606",
-      "1654",
-      "1736",
-      "1747",
-      "1763",
-      "1764",
-      "1767",
-      "1769",
-      "1815",
-      "1822",
-      "1833",
-      "1844",
-      "1870",
-      "1884",
-      "1906",
-      "1919",
-      "1934",
-      "2010",
-      "2017",
-      "2029",
-      "2074",
-      "2098",
-      "2101",
-      "2103",
-      "2104",
-      "2108",
-      "2109",
-      "2116",
-      "2128",
-      "2130",
-      "2139",
-      "2183"
     ],
     "acceptance-criteria": {
       "single-vaccine-validity-offset": 21,

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/verificationRules.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/verificationRules.json
@@ -190,7 +190,7 @@
     },
     {
       "id": "VR-CH-0005",
-      "description": "If the vaccine requires one dose and there was no previous infection, the validation is valid after 15 days ",
+      "description": "If the vaccine requires one dose, and only one dose was administered, it is valid after 21 days ",
       "inputParameter": "Vaccination Part of the HCert (\"v\") + Valuesets",
       "logic": {
         "if": [
@@ -242,7 +242,7 @@
     },
     {
       "id": "VR-CH-0006",
-      "description": "Today must be less than the vaccination date plus 179 days",
+      "description": "Today must be less than the vaccination date plus 364 days",
       "inputParameter": "Vaccination Part of the HCert (\"v\") + Valuesets",
       "logic": {
         "if": [
@@ -387,7 +387,7 @@
     },
     {
       "id": "TR-CH-0006",
-      "description": "If the test type is \"RAT\" then the validation date must be before the date of sample collection plus 24 hours",
+      "description": "If the test type is \"RAT\" then the validation date must be before the date of sample collection plus 48 hours",
       "inputParameter": "Test Part of the HCert (\"t\")+ validation date (timestamp)+ Valuesets +\"sc\"",
       "logic": {
         "if": [

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/EtagUtilTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/EtagUtilTest.java
@@ -41,7 +41,7 @@ public class EtagUtilTest {
 
     @Test
     public void testFileHash() throws Exception {
-        String expected = "71446bd3f94587f788f19c8d4d5ba7f787c0ecdb";
+        String expected = "1108862ae6d605d689269437c8a977103c2f5a29";
         String sha1 = EtagUtil.getSha1HashForFiles(PATH_TO_VERIFICATION_RULES);
         assertEquals(expected, sha1);
         assertNotEquals(expected, EtagUtil.getSha1HashForFiles(PATH_TO_TEST_VERIFICATION_RULES));

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/EtagUtilTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/EtagUtilTest.java
@@ -41,7 +41,7 @@ public class EtagUtilTest {
 
     @Test
     public void testFileHash() throws Exception {
-        String expected = "1108862ae6d605d689269437c8a977103c2f5a29";
+        String expected = "739f0b5691a304570d8f9afd336c0b4dca6b9ccf";
         String sha1 = EtagUtil.getSha1HashForFiles(PATH_TO_VERIFICATION_RULES);
         assertEquals(expected, sha1);
         assertNotEquals(expected, EtagUtil.getSha1HashForFiles(PATH_TO_TEST_VERIFICATION_RULES));


### PR DESCRIPTION
This pull-request updates the national rules as follows:
* All RAT (Rapid Antigen Tests) are accepted, as long as another country in Europe issues certificates for this test. We trust the issuing state to only use tests on the HSC common list (JRC). 
* Accepted vaccines with only one dose required (only Janssen at the moment) are valid after 21 days if only one dose administered (1/1), but immediately valid if two or more doses were administered (2/2, 3/3,...). 
* Update descriptions of some rules 