### PR TITLE
Revert "two-doses-vaccine-validity-offset"

### DIFF
--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/verificationRules.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/verificationRules.json
@@ -178,9 +178,7 @@
                   {
                     "var": "payload.v.0.dt"
                   },
-                  {
-                    "var": "external.valueSets.acceptance-criteria.two-doses-vaccine-validity-offset"
-                  },
+                  0,
                   "day"
                 ]
               }
@@ -672,7 +670,6 @@
     ],
     "acceptance-criteria": {
       "single-vaccine-validity-offset": 21,
-      "two-doses-vaccine-validity-offset": 0,
       "vaccine-immunity": 364,
       "rat-test-validity": 48,
       "pcr-test-validity": 72,

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/EtagUtilTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/EtagUtilTest.java
@@ -41,7 +41,7 @@ public class EtagUtilTest {
 
     @Test
     public void testFileHash() throws Exception {
-        String expected = "739f0b5691a304570d8f9afd336c0b4dca6b9ccf";
+        String expected = "69207e46102bc25f39024c0645df65593a741c3a";
         String sha1 = EtagUtil.getSha1HashForFiles(PATH_TO_VERIFICATION_RULES);
         assertEquals(expected, sha1);
         assertNotEquals(expected, EtagUtil.getSha1HashForFiles(PATH_TO_TEST_VERIFICATION_RULES));


### PR DESCRIPTION
We cannot introduce "two-doses-vaccine-validity-offset" as model of
Android SDK does not contain this field and therefore is not accessible
from rules