### PR TITLE
Feature/up to date fix

### DIFF
--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/VerifierDataService.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/VerifierDataService.java
@@ -76,5 +76,5 @@ public interface VerifierDataService {
     /** returns the highest DSC pk id */
     public long findMaxDscPkId();
 
-    public int getMaxDscBatchCount();
+    public int getDscBatchSize();
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/impl/JdbcRevokedCertDataServiceImpl.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/impl/JdbcRevokedCertDataServiceImpl.java
@@ -29,11 +29,12 @@ public class JdbcRevokedCertDataServiceImpl implements RevokedCertDataService {
     private static final Logger logger =
             LoggerFactory.getLogger(JdbcRevokedCertDataServiceImpl.class);
 
-    private static final int MAX_REVOKED_CERT_BATCH_COUNT = 1000;
+    private final int revokedCertBatchSize;
     private final NamedParameterJdbcTemplate jt;
 
-    public JdbcRevokedCertDataServiceImpl(DataSource dataSource) {
+    public JdbcRevokedCertDataServiceImpl(DataSource dataSource, int revokedCertBatchSize) {
         this.jt = new NamedParameterJdbcTemplate(dataSource);
+        this.revokedCertBatchSize = revokedCertBatchSize;
     }
 
     @Transactional(readOnly = false)
@@ -90,10 +91,10 @@ public class JdbcRevokedCertDataServiceImpl implements RevokedCertDataService {
                 "select pk_revoked_cert_id, uvci from t_revoked_cert"
                         + " where pk_revoked_cert_id > :since"
                         + " order by pk_revoked_cert_id asc"
-                        + " limit :max_batch_count";
+                        + " limit :batch_size";
         MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue("since", since);
-        params.addValue("max_batch_count", MAX_REVOKED_CERT_BATCH_COUNT);
+        params.addValue("batch_size", revokedCertBatchSize);
         return jt.query(sql, params, new RevokedCertRowMapper());
     }
 

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/resources/db/migration/pgsql/V0_6__reset_revoked_certs_sequence.sql
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/resources/db/migration/pgsql/V0_6__reset_revoked_certs_sequence.sql
@@ -1,0 +1,8 @@
+/*
+ * Created by Ubique Innovation AG
+ * https://www.ubique.ch
+ * Copyright (c) 2021. All rights reserved.
+ */
+
+delete from t_revoked_cert;
+select setval('t_revoked_cert_pk_revoked_cert_id_seq', 1);

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/resources/db/migration/pgsql_cluster/V0_6__reset_revoked_certs_sequence.sql
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/resources/db/migration/pgsql_cluster/V0_6__reset_revoked_certs_sequence.sql
@@ -1,0 +1,8 @@
+/*
+ * Created by Ubique Innovation AG
+ * https://www.ubique.ch
+ * Copyright (c) 2021. All rights reserved.
+ */
+
+delete from t_revoked_cert;
+select setval('t_revoked_cert_pk_revoked_cert_id_seq', 1);

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/data/config/TestConfig.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/data/config/TestConfig.java
@@ -15,6 +15,7 @@ import ch.admin.bag.covidcertificate.backend.verifier.data.VerifierDataService;
 import ch.admin.bag.covidcertificate.backend.verifier.data.impl.JdbcAppTokenDataServiceImpl;
 import ch.admin.bag.covidcertificate.backend.verifier.data.impl.JdbcVerifierDataServiceImpl;
 import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Profile;
@@ -23,9 +24,12 @@ import org.springframework.context.annotation.Profile;
 @TestConfiguration
 public class TestConfig {
 
+    @Value("${ws.keys.batch-size:1000}")
+    protected Integer dscBatchSize;
+
     @Bean
     public VerifierDataService verifierDataService(DataSource dataSource) {
-        return new JdbcVerifierDataServiceImpl(dataSource);
+        return new JdbcVerifierDataServiceImpl(dataSource, dscBatchSize);
     }
 
     @Bean

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/test/resources/application-test.properties
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/test/resources/application-test.properties
@@ -1,0 +1,2 @@
+revocationList.batch-size=20000
+ws.keys.batch-size=1000

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-sync/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/sync/config/SyncBaseConfig.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-sync/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/sync/config/SyncBaseConfig.java
@@ -37,6 +37,9 @@ public abstract class SyncBaseConfig {
     @Value("${dgc.clientcert.password}")
     String authClientCertPassword;
 
+    @Value("${ws.keys.batch-size:1000}")
+    protected Integer dscBatchSize;
+
     public abstract DataSource dataSource();
 
     public abstract Flyway flyway();
@@ -62,7 +65,7 @@ public abstract class SyncBaseConfig {
 
     @Bean
     public VerifierDataService verifierDataService(DataSource dataSource) {
-        return new JdbcVerifierDataServiceImpl(dataSource);
+        return new JdbcVerifierDataServiceImpl(dataSource, dscBatchSize);
     }
 
     @Bean

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-sync/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/sync/config/SyncSchedulingBaseConfig.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-sync/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/sync/config/SyncSchedulingBaseConfig.java
@@ -32,6 +32,7 @@ public class SyncSchedulingBaseConfig {
     @Scheduled(cron = "${dgc.sync.cron}")
     @SchedulerLock(name = "DGC_download", lockAtLeastFor = "PT15S")
     public void dgcSyncCron() {
+        LockAssert.assertLocked();
         dgcSyncer.sync();
     }
 

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-sync/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/sync/config/TestConfig.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-sync/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/sync/config/TestConfig.java
@@ -32,6 +32,9 @@ public class TestConfig {
     @Value("${dgc.baseurl}")
     String baseurl = "https://testurl.europa.eu";
 
+    @Value("${ws.keys.batch-size:1000}")
+    protected Integer dscBatchSize;
+
     @Bean
     public DgcSyncer dgcSyncer(DgcClient dgcClient, VerifierDataService verifierDataService) {
         logger.info("Instantiated DGC Syncer with baseurl: {}", baseurl);
@@ -46,7 +49,7 @@ public class TestConfig {
 
     @Bean
     public VerifierDataService verifierDataService(DataSource dataSource) {
-        return new JdbcVerifierDataServiceImpl(dataSource);
+        return new JdbcVerifierDataServiceImpl(dataSource, dscBatchSize);
     }
 
     @Bean

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/SchedulingConfig.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/SchedulingConfig.java
@@ -33,6 +33,14 @@ public class SchedulingConfig {
         this.revocationListSyncer = revocationListSyncer;
     }
 
+    // Sync revocation list on start up
+    @Scheduled(fixedDelay = Long.MAX_VALUE, initialDelay = 0)
+    @SchedulerLock(name = "revocation_list_sync", lockAtLeastFor = "PT15S")
+    public void syncRevocationListOnStartup() {
+        LockAssert.assertLocked();
+        revocationListSyncer.updateRevokedCerts();
+    }
+
     // Sync revocation list every full hour (default)
     @Scheduled(cron = "${revocationList.sync.cron:0 0 * ? * *}")
     @SchedulerLock(name = "revocation_list_sync", lockAtLeastFor = "PT15S")

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/WsBaseConfig.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/WsBaseConfig.java
@@ -71,6 +71,12 @@ public abstract class WsBaseConfig implements WebMvcConfigurer {
     @Value("${revocationList.baseurl}")
     String revokedCertsBaseUrl;
 
+    @Value("${revocationList.batch-size:20000}")
+    protected Integer revokedCertBatchSize;
+
+    @Value("${ws.keys.batch-size:1000}")
+    protected Integer dscBatchSize;
+
     public abstract DataSource dataSource();
 
     public abstract Flyway flyway();
@@ -140,7 +146,7 @@ public abstract class WsBaseConfig implements WebMvcConfigurer {
 
     @Bean
     public VerifierDataService verifierDataService(DataSource dataSource) {
-        return new JdbcVerifierDataServiceImpl(dataSource);
+        return new JdbcVerifierDataServiceImpl(dataSource, dscBatchSize);
     }
 
     @Bean
@@ -177,7 +183,7 @@ public abstract class WsBaseConfig implements WebMvcConfigurer {
 
     @Bean
     public RevokedCertDataService revokedCertDataService(DataSource dataSource) {
-        return new JdbcRevokedCertDataServiceImpl(dataSource);
+        return new JdbcRevokedCertDataServiceImpl(dataSource, revokedCertBatchSize);
     }
 
     @Bean

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/KeyController.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/KeyController.java
@@ -97,7 +97,7 @@ public class KeyController {
                         .max()
                         .orElse(verifierDataService.findMaxDscPkId());
         headers.add(NEXT_SINCE_HEADER, nextSince.toString());
-        boolean upToDate = dscs.size() < verifierDataService.getMaxDscBatchCount();
+        boolean upToDate = dscs.size() < verifierDataService.getDscBatchSize();
         headers.add(UP_TO_DATE_HEADER, String.valueOf(upToDate));
         return headers;
     }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/KeyController.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/KeyController.java
@@ -127,7 +127,7 @@ public class KeyController {
                         Date.from(previousBucketRelease.toInstant()));
 
         // check etag
-        String currentEtag = String.valueOf(EtagUtil.getUnsortedListHashcode(activeKeyIds));
+        String currentEtag = EtagUtil.getUnsortedListEtag(activeKeyIds);
         if (request.checkNotModified(currentEtag)) {
             return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build();
         }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/KeyController.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/KeyController.java
@@ -97,9 +97,8 @@ public class KeyController {
                         .max()
                         .orElse(verifierDataService.findMaxDscPkId());
         headers.add(NEXT_SINCE_HEADER, nextSince.toString());
-        if (dscs.size() < verifierDataService.getMaxDscBatchCount()) {
-            headers.add(UP_TO_DATE_HEADER, "true");
-        }
+        boolean upToDate = dscs.size() < verifierDataService.getMaxDscBatchCount();
+        headers.add(UP_TO_DATE_HEADER, String.valueOf(upToDate));
         return headers;
     }
 

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/KeyControllerV2.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/KeyControllerV2.java
@@ -81,9 +81,8 @@ public class KeyControllerV2 {
         long maxDscPkId = upTo != null ? upTo : verifierDataService.findMaxDscPkId();
         Long nextSince = dscs.stream().mapToLong(ClientCert::getPkId).max().orElse(maxDscPkId);
         headers.add(NEXT_SINCE_HEADER, nextSince.toString());
-        if (nextSince >= maxDscPkId) {
-            headers.add(UP_TO_DATE_HEADER, "true");
-        }
+        boolean upToDate = nextSince >= maxDscPkId;
+        headers.add(UP_TO_DATE_HEADER, String.valueOf(upToDate));
         return headers;
     }
 

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/KeyControllerV2.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/KeyControllerV2.java
@@ -104,7 +104,7 @@ public class KeyControllerV2 {
         List<String> activeKeyIds = verifierDataService.findActiveDscKeyIds();
 
         // check etag
-        String currentEtag = String.valueOf(EtagUtil.getUnsortedListHashcode(activeKeyIds));
+        String currentEtag = EtagUtil.getUnsortedListEtag(activeKeyIds);
         if (request.checkNotModified(currentEtag)) {
             return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build();
         }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/RevocationListController.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/RevocationListController.java
@@ -69,7 +69,7 @@ public class RevocationListController {
         response.setRevokedCerts(revokedCerts);
 
         // check etag
-        String currentEtag = String.valueOf(EtagUtil.getUnsortedListHashcode(revokedCerts));
+        String currentEtag = EtagUtil.getUnsortedListEtag(revokedCerts);
         if (request.checkNotModified(currentEtag)) {
             return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build();
         }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/RevocationListControllerV2.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/RevocationListControllerV2.java
@@ -73,9 +73,8 @@ public class RevocationListControllerV2 {
         Long nextSince =
                 revokedCerts.stream().mapToLong(DbRevokedCert::getPkId).max().orElse(maxPkId);
         headers.add(NEXT_SINCE_HEADER, nextSince.toString());
-        if (nextSince >= maxPkId) {
-            headers.add(UP_TO_DATE_HEADER, "true");
-        }
+        boolean upToDate = nextSince >= maxPkId;
+        headers.add(UP_TO_DATE_HEADER, String.valueOf(upToDate));
         return headers;
     }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/dev/DevController.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/dev/DevController.java
@@ -17,7 +17,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
@@ -25,12 +24,8 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @Documentation(description = "mocks endpoints that are not available during local development")
 public class DevController {
 
-    private static final String NEXT_SINCE_HEADER = "X-Next-Since";
-    private static final String UP_TO_DATE_HEADER = "up-to-date";
-
     @GetMapping(value = "/v1/revocation-list")
-    public @ResponseBody ResponseEntity<List<String>> getMockRevokedCerts(
-            @RequestParam(required = false) String since) {
+    public @ResponseBody ResponseEntity<List<String>> getMockRevokedCerts() {
         List<String> response = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             response.add("urn:uvci:01:CH:MOCK" + i);

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/dev/DevController.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/dev/DevController.java
@@ -10,11 +10,9 @@
 
 package ch.admin.bag.covidcertificate.backend.verifier.ws.controller.dev;
 
-import ch.admin.bag.covidcertificate.backend.verifier.ws.utils.CacheUtil;
 import ch.ubique.openapi.docannotations.Documentation;
 import java.util.ArrayList;
 import java.util.List;
-import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -37,10 +35,6 @@ public class DevController {
         for (int i = 0; i < 10; i++) {
             response.add("urn:uvci:01:CH:MOCK" + i);
         }
-        return ResponseEntity.ok()
-                .header(NEXT_SINCE_HEADER, "1000")
-                .header(UP_TO_DATE_HEADER, "true")
-                .cacheControl(CacheControl.maxAge(CacheUtil.REVOCATION_LIST_MAX_AGE))
-                .body(response);
+        return ResponseEntity.ok(response);
     }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/utils/EtagUtil.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/utils/EtagUtil.java
@@ -24,14 +24,17 @@ public class EtagUtil {
 
     private EtagUtil() {}
 
+    private static final String WEAK_PREFIX = "W/";
+
     /**
-     * generates a hashcode for a list that does not depend on element order
+     * generates a weak etag for a list that does not depend on element order
      *
      * @param list
      * @return
      */
-    public static int getUnsortedListHashcode(List<String> list) {
-        return list != null ? list.stream().map(Objects::hash).reduce(0, (a, b) -> a ^ b) : 0;
+    public static String getUnsortedListEtag(List<String> list) {
+        int hash = list != null ? list.stream().map(Objects::hash).reduce(0, (a, b) -> a ^ b) : 0;
+        return WEAK_PREFIX + "\"" + hash + "\"";
     }
 
     public static String getSha1HashForFiles(String... pathToFiles)
@@ -53,6 +56,6 @@ public class EtagUtil {
                 }
             }
         }
-        return Hex.encodeHexString(sha1.digest());
+        return WEAK_PREFIX + "\"" + Hex.encodeHexString(sha1.digest()) + "\"";
     }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/application-local.properties
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/application-local.properties
@@ -11,3 +11,6 @@ server.port=8081
 
 revocationList.baseurl=http://localhost:8081
 revocationList.sync.cron=0 * * ? * *
+
+revocationList.batch-size=4
+ws.keys.batch-size=3

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/EtagUtilTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/EtagUtilTest.java
@@ -23,16 +23,16 @@ import org.junit.jupiter.api.Test;
 
 public class EtagUtilTest {
     @Test
-    public void testUnsortedListHashcode() {
-        int expected = 100548;
+    public void testUnsortedListEtag() {
+        String expected = "W/\"100548\"";
         List<String> list = new ArrayList<>(List.of("a", "bc", "def"));
-        int hashcode = EtagUtil.getUnsortedListHashcode(list);
-        assertEquals(expected, hashcode);
+        String actual = EtagUtil.getUnsortedListEtag(list);
+        assertEquals(expected, actual);
         Collections.reverse(list);
-        assertEquals(expected, EtagUtil.getUnsortedListHashcode(list));
+        assertEquals(expected, EtagUtil.getUnsortedListEtag(list));
         list.remove(0);
         list.add("g");
-        assertNotEquals(hashcode, EtagUtil.getUnsortedListHashcode(list));
+        assertNotEquals(actual, EtagUtil.getUnsortedListEtag(list));
     }
 
     private static final String PATH_TO_VERIFICATION_RULES = "classpath:verificationRules.json";
@@ -41,7 +41,7 @@ public class EtagUtilTest {
 
     @Test
     public void testFileHash() throws Exception {
-        String expected = "69207e46102bc25f39024c0645df65593a741c3a";
+        String expected = "W/\"69207e46102bc25f39024c0645df65593a741c3a\"";
         String sha1 = EtagUtil.getSha1HashForFiles(PATH_TO_VERIFICATION_RULES);
         assertEquals(expected, sha1);
         assertNotEquals(expected, EtagUtil.getSha1HashForFiles(PATH_TO_TEST_VERIFICATION_RULES));
@@ -49,7 +49,7 @@ public class EtagUtilTest {
 
     @Test
     public void testFileHashMultiple() throws Exception {
-        String expected = "19d26e8cfc5a14fbdbaf107c933811e1988f1443";
+        String expected = "W/\"19d26e8cfc5a14fbdbaf107c933811e1988f1443\"";
         List<String> pathsToValueSets =
                 ValueSetsController.PATHS_TO_VALUE_SETS.stream()
                         .map(p -> "classpath:" + p)

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/KeyControllerV2Test.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/KeyControllerV2Test.java
@@ -271,7 +271,7 @@ public abstract class KeyControllerV2Test extends BaseControllerTest {
         }
 
         // assert headers
-        assertEquals(expectedUpToDate ? "true" : null, response.getHeader(UP_TO_DATE_HEADER));
+        assertEquals(expectedUpToDate ? "true" : "false", response.getHeader(UP_TO_DATE_HEADER));
         assertEquals(
                 String.valueOf(
                         Math.max((int) verifierDataService.findMaxDscPkId() - dscs.size(), since)

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/KeyControllerV2Test.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/KeyControllerV2Test.java
@@ -68,7 +68,7 @@ public abstract class KeyControllerV2Test extends BaseControllerTest {
 
     @BeforeAll
     public void setup() {
-        for (int i = 0; i < verifierDataService.getMaxDscBatchCount() * 10; i++) {
+        for (int i = 0; i < verifierDataService.getDscBatchSize() * 10; i++) {
             suffixes.add(i);
         }
     }
@@ -197,8 +197,7 @@ public abstract class KeyControllerV2Test extends BaseControllerTest {
 
         // test batching
         int batchCount = 4;
-        dscs.addAll(
-                insertNDscs(cscaId, verifierDataService.getMaxDscBatchCount() * (batchCount - 1)));
+        dscs.addAll(insertNDscs(cscaId, verifierDataService.getDscBatchSize() * (batchCount - 1)));
 
         // upTo set so no batching kicks in
         since = null;
@@ -255,7 +254,7 @@ public abstract class KeyControllerV2Test extends BaseControllerTest {
         int upperCutCount = Math.max(0, (int) verifierDataService.findMaxDscPkId() - upTo);
         int expectedSize =
                 Math.min(
-                        verifierDataService.getMaxDscBatchCount(),
+                        verifierDataService.getDscBatchSize(),
                         Math.max(0, dscs.size() - lowerCutCount - upperCutCount));
         assertEquals(expectedSize, certs.size());
 

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/RevocationListControllerTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/RevocationListControllerTest.java
@@ -95,7 +95,7 @@ public abstract class RevocationListControllerTest extends BaseControllerTest {
 
     @Test
     public void notModifiedTest() throws Exception {
-        String expectedEtag = "\"" + EtagUtil.getUnsortedListHashcode(List.of(REVOKED_CERT)) + "\"";
+        String expectedEtag = EtagUtil.getUnsortedListEtag(List.of(REVOKED_CERT));
 
         // get current etag
         setupExternalRevocationListMock(2);

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/ValueSetsControllerTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/ValueSetsControllerTest.java
@@ -114,10 +114,8 @@ public abstract class ValueSetsControllerTest extends BaseControllerTest {
                         .map(p -> "classpath:" + p)
                         .collect(Collectors.toList());
         String expectedEtag =
-                "\""
-                        + EtagUtil.getSha1HashForFiles(
-                                pathsToValueSets.toArray(new String[pathsToValueSets.size()]))
-                        + "\"";
+                EtagUtil.getSha1HashForFiles(
+                        pathsToValueSets.toArray(new String[pathsToValueSets.size()]));
 
         // get current etag
         MockHttpServletResponse response =

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/VerificationRulesControllerTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/VerificationRulesControllerTest.java
@@ -59,8 +59,7 @@ public abstract class VerificationRulesControllerTest extends BaseControllerTest
 
     @Test
     public void notModifiedTest() throws Exception {
-        String expectedEtag =
-                "\"" + EtagUtil.getSha1HashForFiles(PATH_TO_VERIFICATION_RULES) + "\"";
+        String expectedEtag = EtagUtil.getSha1HashForFiles(PATH_TO_VERIFICATION_RULES);
 
         // get current etag
         MockHttpServletResponse response =

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/resources/application-test.properties
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/resources/application-test.properties
@@ -2,3 +2,6 @@ revocationList.baseurl=https://testurl.admin.ch/api/
 
 ws.keys.update.max-age=PT2M
 ws.keys.list.max-age=PT3M
+
+revocationList.batch-size=20000
+ws.keys.batch-size=1000

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/resources/http/verifier-ws.http
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/resources/http/verifier-ws.http
@@ -10,7 +10,6 @@ Authorization: Bearer {{apiKey}}
 ### get active cert key ids
 GET {{baseUrl}}/v2/keys/list
 Accept: application/json
-If-None-Match: "-720957702"
 Authorization: Bearer {{apiKey}}
 
 ### get revocation list


### PR DESCRIPTION
this pull request fixes the up-to-date header for ios, so that up-to-date is set to false (instead of not being set) if it is not true. batch sizes for dsc and revocation list are now parameterizable. etags were fixed to be identified as weak etags to enable gzip compression