### PR TITLE
stop revoked cert sequence from incrementing on every upsert

### DIFF
--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/resources/db/migration/pgsql/V0_6__reset_revoked_certs_sequence.sql
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/resources/db/migration/pgsql/V0_6__reset_revoked_certs_sequence.sql
@@ -1,0 +1,8 @@
+/*
+ * Created by Ubique Innovation AG
+ * https://www.ubique.ch
+ * Copyright (c) 2021. All rights reserved.
+ */
+
+delete from t_revoked_cert;
+select setval('t_revoked_cert_pk_revoked_cert_id_seq', 1);

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/resources/db/migration/pgsql_cluster/V0_6__reset_revoked_certs_sequence.sql
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/resources/db/migration/pgsql_cluster/V0_6__reset_revoked_certs_sequence.sql
@@ -1,0 +1,8 @@
+/*
+ * Created by Ubique Innovation AG
+ * https://www.ubique.ch
+ * Copyright (c) 2021. All rights reserved.
+ */
+
+delete from t_revoked_cert;
+select setval('t_revoked_cert_pk_revoked_cert_id_seq', 1);

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-sync/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/sync/config/SyncSchedulingBaseConfig.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-sync/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/sync/config/SyncSchedulingBaseConfig.java
@@ -32,6 +32,7 @@ public class SyncSchedulingBaseConfig {
     @Scheduled(cron = "${dgc.sync.cron}")
     @SchedulerLock(name = "DGC_download", lockAtLeastFor = "PT15S")
     public void dgcSyncCron() {
+        LockAssert.assertLocked();
         dgcSyncer.sync();
     }
 

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/SchedulingConfig.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/SchedulingConfig.java
@@ -33,6 +33,14 @@ public class SchedulingConfig {
         this.revocationListSyncer = revocationListSyncer;
     }
 
+    // Sync revocation list on start up
+    @Scheduled(fixedDelay = Long.MAX_VALUE, initialDelay = 0)
+    @SchedulerLock(name = "revocation_list_sync", lockAtLeastFor = "PT15S")
+    public void syncRevocationListOnStartup() {
+        LockAssert.assertLocked();
+        revocationListSyncer.updateRevokedCerts();
+    }
+
     // Sync revocation list every full hour (default)
     @Scheduled(cron = "${revocationList.sync.cron:0 0 * ? * *}")
     @SchedulerLock(name = "revocation_list_sync", lockAtLeastFor = "PT15S")

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/dev/DevController.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/dev/DevController.java
@@ -17,7 +17,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
@@ -25,12 +24,8 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @Documentation(description = "mocks endpoints that are not available during local development")
 public class DevController {
 
-    private static final String NEXT_SINCE_HEADER = "X-Next-Since";
-    private static final String UP_TO_DATE_HEADER = "up-to-date";
-
     @GetMapping(value = "/v1/revocation-list")
-    public @ResponseBody ResponseEntity<List<String>> getMockRevokedCerts(
-            @RequestParam(required = false) String since) {
+    public @ResponseBody ResponseEntity<List<String>> getMockRevokedCerts() {
         List<String> response = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             response.add("urn:uvci:01:CH:MOCK" + i);


### PR DESCRIPTION
this pull request fixes the revoked cert upsert method, so that the revoked cert table sequence doesn't get incremented for every attempted insert of a revoked uvci that is actually already in the database. also the revoked cert syncer is now run on startup