### PR TITLE
Return DCCs with multiple entries (of different types) as invalid

### DIFF
--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/verificationRules.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/verificationRules.json
@@ -70,9 +70,7 @@
       "logic": {
         "if": [
           {
-            "var": [
-              "payload.v.0"
-            ]
+            "var": "payload.v.0"
           },
           {
             "if": [
@@ -81,9 +79,7 @@
                   {
                     "!": [
                       {
-                        "var": [
-                          "payload.v.1"
-                        ]
+                        "var": "payload.v.1"
                       }
                     ]
                   },
@@ -97,9 +93,7 @@
                   {
                     "!": [
                       {
-                        "var": [
-                          "payload.t.0"
-                        ]
+                        "var": "payload.t.0"
                       }
                     ]
                   }
@@ -396,9 +390,7 @@
       "logic": {
         "if": [
           {
-            "var": [
-              "payload.t.0"
-            ]
+            "var": "payload.t.0"
           },
           {
             "if": [
@@ -407,9 +399,7 @@
                   {
                     "!": [
                       {
-                        "var": [
-                          "payload.t.1"
-                        ]
+                        "var": "payload.t.1"
                       }
                     ]
                   },
@@ -423,9 +413,7 @@
                   {
                     "!": [
                       {
-                        "var": [
-                          "payload.v.0"
-                        ]
+                        "var": "payload.v.0"
                       }
                     ]
                   }
@@ -635,27 +623,21 @@
                   {
                     "!": [
                       {
-                        "var": [
-                          "payload.r.1"
-                        ]
+                        "var": "payload.r.1"
                       }
                     ]
                   },
                   {
                     "!": [
                       {
-                        "var": [
-                          "payload.v.0"
-                        ]
+                        "var": "payload.v.0"
                       }
                     ]
                   },
                   {
                     "!": [
                       {
-                        "var": [
-                          "payload.t.0"
-                        ]
+                        "var": "payload.t.0"
                       }
                     ]
                   }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/verificationRules.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/verificationRules.json
@@ -90,9 +90,7 @@
                   {
                     "!": [
                       {
-                        "var": [
-                          "payload.r.0"
-                        ]
+                        "var": "payload.r.0"
                       }
                     ]
                   },
@@ -418,9 +416,7 @@
                   {
                     "!": [
                       {
-                        "var": [
-                          "payload.r.0"
-                        ]
+                        "var": "payload.r.0"
                       }
                     ]
                   },
@@ -630,9 +626,7 @@
       "logic": {
         "if": [
           {
-            "var": [
-              "payload.r.0"
-            ]
+            "var": "payload.r.0"
           },
           {
             "if": [

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/verificationRules.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/verificationRules.json
@@ -68,10 +68,50 @@
       "description": "At most one v-event.",
       "inputParameter": "Entire HCert JSON (\"v\")",
       "logic": {
-        "!": [
+        "if": [
           {
-            "var": "payload.v.1"
-          }
+            "var": [
+              "payload.v.0"
+            ]
+          },
+          {
+            "if": [
+              {
+                "and": [
+                  {
+                    "!": [
+                      {
+                        "var": [
+                          "payload.v.1"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "!": [
+                      {
+                        "var": [
+                          "payload.r.0"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "!": [
+                      {
+                        "var": [
+                          "payload.t.0"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              true,
+              false
+            ]
+          },
+          true
         ]
       }
     },
@@ -356,10 +396,50 @@
       "description": "At most one t-event.",
       "inputParameter": "Entire HCert JSON (\"t\")",
       "logic": {
-        "!": [
+        "if": [
           {
-            "var": "payload.t.1"
-          }
+            "var": [
+              "payload.t.0"
+            ]
+          },
+          {
+            "if": [
+              {
+                "and": [
+                  {
+                    "!": [
+                      {
+                        "var": [
+                          "payload.t.1"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "!": [
+                      {
+                        "var": [
+                          "payload.r.0"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "!": [
+                      {
+                        "var": [
+                          "payload.v.0"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              true,
+              false
+            ]
+          },
+          true
         ]
       }
     },
@@ -548,10 +628,50 @@
       "description": "At most one r-event.",
       "inputParameter": "Entire HCert JSON (\"r\")",
       "logic": {
-        "!": [
+        "if": [
           {
-            "var": "payload.r.1"
-          }
+            "var": [
+              "payload.r.0"
+            ]
+          },
+          {
+            "if": [
+              {
+                "and": [
+                  {
+                    "!": [
+                      {
+                        "var": [
+                          "payload.r.1"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "!": [
+                      {
+                        "var": [
+                          "payload.v.0"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "!": [
+                      {
+                        "var": [
+                          "payload.t.0"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              true,
+              false
+            ]
+          },
+          true
         ]
       }
     },

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/EtagUtilTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/EtagUtilTest.java
@@ -41,7 +41,7 @@ public class EtagUtilTest {
 
     @Test
     public void testFileHash() throws Exception {
-        String expected = "W/\"df47b88dfd2335c6f5f3221187d1622bca79427f\"";
+        String expected = "W/\"2b4a650db8aa2140d453a167da3dac67ce16eca0\"";
         String sha1 = EtagUtil.getSha1HashForFiles(PATH_TO_VERIFICATION_RULES);
         assertEquals(expected, sha1);
         assertNotEquals(expected, EtagUtil.getSha1HashForFiles(PATH_TO_TEST_VERIFICATION_RULES));

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/EtagUtilTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/EtagUtilTest.java
@@ -41,7 +41,7 @@ public class EtagUtilTest {
 
     @Test
     public void testFileHash() throws Exception {
-        String expected = "W/\"69207e46102bc25f39024c0645df65593a741c3a\"";
+        String expected = "W/\"eb7ebe71b93db2fa6fbd108018b3718c260bd252\"";
         String sha1 = EtagUtil.getSha1HashForFiles(PATH_TO_VERIFICATION_RULES);
         assertEquals(expected, sha1);
         assertNotEquals(expected, EtagUtil.getSha1HashForFiles(PATH_TO_TEST_VERIFICATION_RULES));

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/EtagUtilTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/EtagUtilTest.java
@@ -41,7 +41,7 @@ public class EtagUtilTest {
 
     @Test
     public void testFileHash() throws Exception {
-        String expected = "W/\"eb7ebe71b93db2fa6fbd108018b3718c260bd252\"";
+        String expected = "W/\"df47b88dfd2335c6f5f3221187d1622bca79427f\"";
         String sha1 = EtagUtil.getSha1HashForFiles(PATH_TO_VERIFICATION_RULES);
         assertEquals(expected, sha1);
         assertNotEquals(expected, EtagUtil.getSha1HashForFiles(PATH_TO_TEST_VERIFICATION_RULES));


### PR DESCRIPTION
This PR makes sure that DCCs with multiple entries of different types are marked/returned as invalid. The next version of the app removes this restriction in favor of business rules, so this can be changed dynamically in the future (if needed).