### PR TITLE
Feature/revocation list v2 improvements

### DIFF
--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/RevokedCertDataService.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/RevokedCertDataService.java
@@ -12,6 +12,7 @@ package ch.admin.bag.covidcertificate.backend.verifier.data;
 
 import ch.admin.bag.covidcertificate.backend.verifier.model.DbRevokedCert;
 import ch.admin.bag.covidcertificate.backend.verifier.model.cert.db.RevokedCertsUpdateResponse;
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 
@@ -20,9 +21,18 @@ public interface RevokedCertDataService {
     /** upserts the given revoked uvcis into the db */
     public RevokedCertsUpdateResponse replaceRevokedCerts(Set<String> revokedUvcis);
 
-    /** returns the next batch of revoked certs after `since` */
-    public List<DbRevokedCert> findRevokedCerts(Long since);
+    /**
+     * returns the next batch of released revoked certs after `since`
+     *
+     * @param since
+     * @param now
+     */
+    public List<DbRevokedCert> findReleasedRevokedCerts(Long since, Instant now);
 
-    /** returns the highest revoked cert pk id */
-    public long findMaxRevokedCertPkId();
+    /**
+     * returns the highest released revoked cert pk id
+     *
+     * @param now
+     */
+    public long findMaxReleasedRevokedCertPkId(Instant now);
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/RevokedCertDataService.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/RevokedCertDataService.java
@@ -35,4 +35,6 @@ public interface RevokedCertDataService {
      * @param now
      */
     public long findMaxReleasedRevokedCertPkId(Instant now);
+
+    public int getRevokedCertBatchSize();
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/impl/JdbcRevokedCertDataServiceImpl.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/impl/JdbcRevokedCertDataServiceImpl.java
@@ -161,4 +161,8 @@ public class JdbcRevokedCertDataServiceImpl implements RevokedCertDataService {
             return 0L;
         }
     }
+
+    public int getRevokedCertBatchSize() {
+        return revokedCertBatchSize;
+    }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/util/CacheUtil.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/util/CacheUtil.java
@@ -32,15 +32,15 @@ public class CacheUtil {
     /**
      * Formats the date to a http timestamp.
      *
-     * @param date
+     * @param instant
      * @return
      */
-    private static String formatHeaderDate(Instant date) {
+    public static String formatHeaderDate(Instant instant) {
         DateTimeFormatter formatter =
                 DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss z")
                         .withLocale(Locale.US)
                         .withZone(ZoneId.of("GMT"));
-        return formatter.format(date);
+        return formatter.format(instant);
     }
 
     public static HttpHeaders createExpiresHeader(Instant expires) {

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/data/RevokedCertDataServiceTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/data/RevokedCertDataServiceTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package ch.admin.bag.covidcertificate.backend.verifier.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import ch.admin.bag.covidcertificate.backend.verifier.data.util.CacheUtil;
+import ch.admin.bag.covidcertificate.backend.verifier.data.util.TestUtil;
+import java.time.Instant;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class RevokedCertDataServiceTest extends BaseDataServiceTest {
+
+    @Autowired RevokedCertDataService revokedCertDataService;
+    @Autowired DataSource dataSource;
+
+    @Test
+    void getAppTokensTest() {
+        Instant now = Instant.now();
+
+        // import revoked certs
+        int releasedRevokedCertCount = 20;
+        revokedCertDataService.replaceRevokedCerts(
+                TestUtil.getRevokedCertUvcis(releasedRevokedCertCount));
+
+        // set imported_at back by one retention bucket period so revoked certs will be released
+        TestUtil.releaseRevokedCerts(jt, now);
+
+        // check released count and max pk id
+        assertEquals(
+                releasedRevokedCertCount,
+                revokedCertDataService.findReleasedRevokedCerts(0L, now).size());
+        long maxReleasedPkId = revokedCertDataService.findMaxReleasedRevokedCertPkId(now);
+
+        // import additional revoked certs which should not be released yet
+        int newRevokedCertCount = 10;
+        revokedCertDataService.replaceRevokedCerts(
+                TestUtil.getRevokedCertUvcis(releasedRevokedCertCount + newRevokedCertCount));
+
+        // check released count and max pk id (unchanged)
+        assertEquals(
+                releasedRevokedCertCount,
+                revokedCertDataService.findReleasedRevokedCerts(0L, now).size());
+        assertEquals(maxReleasedPkId, revokedCertDataService.findMaxReleasedRevokedCertPkId(now));
+
+        // check one revocation retention bucket duration later
+        now = now.plus(CacheUtil.REVOCATION_RETENTION_BUCKET_DURATION);
+        assertEquals(
+                releasedRevokedCertCount + newRevokedCertCount,
+                revokedCertDataService.findReleasedRevokedCerts(0L, now).size());
+        assertEquals(
+                maxReleasedPkId + newRevokedCertCount,
+                revokedCertDataService.findMaxReleasedRevokedCertPkId(now));
+    }
+}

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/data/config/TestConfig.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/data/config/TestConfig.java
@@ -11,9 +11,13 @@
 package ch.admin.bag.covidcertificate.backend.verifier.data.config;
 
 import ch.admin.bag.covidcertificate.backend.verifier.data.AppTokenDataService;
+import ch.admin.bag.covidcertificate.backend.verifier.data.RevokedCertDataService;
 import ch.admin.bag.covidcertificate.backend.verifier.data.VerifierDataService;
 import ch.admin.bag.covidcertificate.backend.verifier.data.impl.JdbcAppTokenDataServiceImpl;
+import ch.admin.bag.covidcertificate.backend.verifier.data.impl.JdbcRevokedCertDataServiceImpl;
 import ch.admin.bag.covidcertificate.backend.verifier.data.impl.JdbcVerifierDataServiceImpl;
+import ch.admin.bag.covidcertificate.backend.verifier.data.util.CacheUtil;
+import java.time.Duration;
 import javax.sql.DataSource;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -35,5 +39,17 @@ public class TestConfig {
     @Bean
     public AppTokenDataService appTokenDataService(DataSource dataSource) {
         return new JdbcAppTokenDataServiceImpl(dataSource);
+    }
+
+    @Bean
+    public RevokedCertDataService revokedCertDataService(
+            DataSource dataSource,
+            @Value("${revocationList.batch-size:20000}") Integer revokedCertBatchSize) {
+        return new JdbcRevokedCertDataServiceImpl(dataSource, revokedCertBatchSize);
+    }
+
+    @Value("${ws.revocation-list.retention-bucket-duration:PT6H}")
+    public void setRevocationRetentionBucketDuration(Duration bucketDuration) {
+        CacheUtil.REVOCATION_RETENTION_BUCKET_DURATION = bucketDuration;
     }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/data/util/TestUtil.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/data/util/TestUtil.java
@@ -13,6 +13,12 @@ package ch.admin.bag.covidcertificate.backend.verifier.data.util;
 import ch.admin.bag.covidcertificate.backend.verifier.model.cert.Algorithm;
 import ch.admin.bag.covidcertificate.backend.verifier.model.cert.db.DbCsca;
 import ch.admin.bag.covidcertificate.backend.verifier.model.cert.db.DbDsc;
+import java.time.Instant;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 public class TestUtil {
 
@@ -53,5 +59,25 @@ public class TestUtil {
         dbDsc.setX("x");
         dbDsc.setY("y");
         return dbDsc;
+    }
+
+    public static Set<String> getRevokedCertUvcis(int count) {
+        Set<String> uvcis = new HashSet<>();
+        for (int i = 0; i < count; i++) {
+            uvcis.add("revoked_cert_uvci_" + i);
+        }
+        return uvcis;
+    }
+
+    public static void releaseRevokedCerts(NamedParameterJdbcTemplate jt, Instant now) {
+        MapSqlParameterSource params =
+                new MapSqlParameterSource(
+                        "imported_at",
+                        Date.from(now.minus(CacheUtil.REVOCATION_RETENTION_BUCKET_DURATION)));
+        jt.update("update t_revoked_cert set imported_at = :imported_at", params);
+    }
+
+    public static void clearRevokedCerts(NamedParameterJdbcTemplate jt) {
+        jt.update("delete from t_revoked_cert", new MapSqlParameterSource());
     }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/WsBaseConfig.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/WsBaseConfig.java
@@ -29,7 +29,7 @@ import ch.admin.bag.covidcertificate.backend.verifier.ws.controller.Verification
 import ch.admin.bag.covidcertificate.backend.verifier.ws.controller.VerificationRulesControllerV2;
 import ch.admin.bag.covidcertificate.backend.verifier.ws.interceptor.HeaderInjector;
 import ch.admin.bag.covidcertificate.backend.verifier.ws.security.signature.JwsMessageConverter;
-import ch.admin.bag.covidcertificate.backend.verifier.ws.utils.CacheUtil;
+import ch.admin.bag.covidcertificate.backend.verifier.data.util.CacheUtil;
 import ch.admin.bag.covidcertificate.backend.verifier.ws.utils.RestTemplateHelper;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -90,9 +90,14 @@ public abstract class WsBaseConfig implements WebMvcConfigurer {
         CacheUtil.KEYS_BUCKET_DURATION = bucketDuration;
     }
 
-    @Value("${ws.revocationList.max-age:PT1M}")
-    public void setRevocationListMaxAge(Duration maxAge) {
-        CacheUtil.REVOCATION_LIST_MAX_AGE = maxAge;
+    @Value("${ws.revocation-list.retention-bucket-duration:PT6H}")
+    public void setRevocationRetentionBucketDuration(Duration bucketDuration) {
+        CacheUtil.REVOCATION_RETENTION_BUCKET_DURATION = bucketDuration;
+    }
+
+    @Value("${ws.revocation-list.v1.max-age:PT1M}")
+    public void setRevocationListV1MaxAge(Duration maxAge) {
+        CacheUtil.REVOCATION_LIST_V1_MAX_AGE = maxAge;
     }
 
     @Value("${ws.verificationRules.max-age:PT1M}")

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/DcgaController.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/DcgaController.java
@@ -11,7 +11,7 @@
 package ch.admin.bag.covidcertificate.backend.verifier.ws.controller;
 
 import ch.admin.bag.covidcertificate.backend.verifier.data.ValueSetDataService;
-import ch.admin.bag.covidcertificate.backend.verifier.ws.utils.CacheUtil;
+import ch.admin.bag.covidcertificate.backend.verifier.data.util.CacheUtil;
 import ch.admin.bag.covidcertificate.backend.verifier.ws.utils.EtagUtil;
 import ch.ubique.openapi.docannotations.Documentation;
 import java.security.NoSuchAlgorithmException;

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/KeyControllerV2.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/KeyControllerV2.java
@@ -11,11 +11,11 @@
 package ch.admin.bag.covidcertificate.backend.verifier.ws.controller;
 
 import ch.admin.bag.covidcertificate.backend.verifier.data.VerifierDataService;
+import ch.admin.bag.covidcertificate.backend.verifier.data.util.CacheUtil;
 import ch.admin.bag.covidcertificate.backend.verifier.model.cert.ActiveCertsResponse;
 import ch.admin.bag.covidcertificate.backend.verifier.model.cert.CertFormat;
 import ch.admin.bag.covidcertificate.backend.verifier.model.cert.CertsResponse;
 import ch.admin.bag.covidcertificate.backend.verifier.model.cert.ClientCert;
-import ch.admin.bag.covidcertificate.backend.verifier.ws.utils.CacheUtil;
 import ch.admin.bag.covidcertificate.backend.verifier.ws.utils.EtagUtil;
 import ch.ubique.openapi.docannotations.Documentation;
 import java.util.List;

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/RevocationListController.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/RevocationListController.java
@@ -10,8 +10,8 @@
 
 package ch.admin.bag.covidcertificate.backend.verifier.ws.controller;
 
+import ch.admin.bag.covidcertificate.backend.verifier.data.util.CacheUtil;
 import ch.admin.bag.covidcertificate.backend.verifier.model.RevocationResponse;
-import ch.admin.bag.covidcertificate.backend.verifier.ws.utils.CacheUtil;
 import ch.admin.bag.covidcertificate.backend.verifier.ws.utils.EtagUtil;
 import ch.ubique.openapi.docannotations.Documentation;
 import java.util.ArrayList;
@@ -75,7 +75,7 @@ public class RevocationListController {
         }
 
         return ResponseEntity.ok()
-                .cacheControl(CacheControl.maxAge(CacheUtil.REVOCATION_LIST_MAX_AGE))
+                .cacheControl(CacheControl.maxAge(CacheUtil.REVOCATION_LIST_V1_MAX_AGE))
                 .body(response);
     }
 

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/ValueSetsController.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/ValueSetsController.java
@@ -13,7 +13,7 @@ package ch.admin.bag.covidcertificate.backend.verifier.ws.controller;
 import ch.admin.bag.covidcertificate.backend.verifier.ws.model.valuesets.TestValueSets;
 import ch.admin.bag.covidcertificate.backend.verifier.ws.model.valuesets.VaccineValueSets;
 import ch.admin.bag.covidcertificate.backend.verifier.ws.model.valuesets.ValueSets;
-import ch.admin.bag.covidcertificate.backend.verifier.ws.utils.CacheUtil;
+import ch.admin.bag.covidcertificate.backend.verifier.data.util.CacheUtil;
 import ch.admin.bag.covidcertificate.backend.verifier.ws.utils.EtagUtil;
 import ch.ubique.openapi.docannotations.Documentation;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/VerificationRulesController.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/VerificationRulesController.java
@@ -10,7 +10,7 @@
 
 package ch.admin.bag.covidcertificate.backend.verifier.ws.controller;
 
-import ch.admin.bag.covidcertificate.backend.verifier.ws.utils.CacheUtil;
+import ch.admin.bag.covidcertificate.backend.verifier.data.util.CacheUtil;
 import ch.admin.bag.covidcertificate.backend.verifier.ws.utils.EtagUtil;
 import ch.ubique.openapi.docannotations.Documentation;
 import com.fasterxml.jackson.databind.JsonNode;

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/VerificationRulesControllerV2.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/VerificationRulesControllerV2.java
@@ -11,7 +11,7 @@
 package ch.admin.bag.covidcertificate.backend.verifier.ws.controller;
 
 import ch.admin.bag.covidcertificate.backend.verifier.data.ValueSetDataService;
-import ch.admin.bag.covidcertificate.backend.verifier.ws.utils.CacheUtil;
+import ch.admin.bag.covidcertificate.backend.verifier.data.util.CacheUtil;
 import ch.admin.bag.covidcertificate.backend.verifier.ws.utils.EtagUtil;
 import ch.ubique.openapi.docannotations.Documentation;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/KeyControllerV2Test.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/KeyControllerV2Test.java
@@ -26,7 +26,7 @@ import ch.admin.bag.covidcertificate.backend.verifier.model.cert.CertsResponse;
 import ch.admin.bag.covidcertificate.backend.verifier.model.cert.ClientCert;
 import ch.admin.bag.covidcertificate.backend.verifier.model.cert.db.DbDsc;
 import ch.admin.bag.covidcertificate.backend.verifier.ws.util.TestHelper;
-import ch.admin.bag.covidcertificate.backend.verifier.ws.utils.CacheUtil;
+import ch.admin.bag.covidcertificate.backend.verifier.data.util.CacheUtil;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/RevocationListControllerV2JwsTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/RevocationListControllerV2JwsTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package ch.admin.bag.covidcertificate.backend.verifier.ws.controller;
+
+import ch.admin.bag.covidcertificate.backend.verifier.ws.security.signature.JwsMessageConverter;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles({"actuator-security"})
+@SpringBootTest(
+        properties = {
+            "ws.monitor.prometheus.user=prometheus",
+            "ws.monitor.prometheus.password=prometheus",
+            "management.endpoints.enabled-by-default=true",
+            "management.endpoints.web.exposure.include=*"
+        })
+@TestInstance(Lifecycle.PER_CLASS)
+public class RevocationListControllerV2JwsTest extends RevocationListControllerV2Test {
+
+    @BeforeAll
+    public void setup() {
+        this.acceptMediaType = JwsMessageConverter.JWS_MEDIA_TYPE;
+        super.setup();
+    }
+}

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/RevocationListControllerV2Test.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/RevocationListControllerV2Test.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2021 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package ch.admin.bag.covidcertificate.backend.verifier.ws.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import ch.admin.bag.covidcertificate.backend.verifier.data.RevokedCertDataService;
+import ch.admin.bag.covidcertificate.backend.verifier.data.util.CacheUtil;
+import ch.admin.bag.covidcertificate.backend.verifier.data.util.TestUtil;
+import ch.admin.bag.covidcertificate.backend.verifier.model.RevocationResponse;
+import ch.admin.bag.covidcertificate.backend.verifier.ws.util.TestHelper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.UnsupportedEncodingException;
+import java.time.Instant;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+public abstract class RevocationListControllerV2Test extends BaseControllerTest {
+    @Autowired protected RevokedCertDataService revokedCertDataService;
+    @Autowired protected DataSource dataSource;
+
+    protected MediaType acceptMediaType;
+
+    private static final String NEXT_SINCE_HEADER = "X-Next-Since";
+    private static final String UP_TO_DATE_HEADER = "up-to-date";
+    private static final String EXPIRES_HEADER = "Expires";
+
+    private static final String SINCE_QUERY_PARAM = "since";
+
+    private String revocationListUrl = "/trust/v2/revocationList";
+    private NamedParameterJdbcTemplate jt;
+
+    void setup() {
+        this.jt = new NamedParameterJdbcTemplate(dataSource);
+    }
+
+    @Test
+    public void getRevokedCertsTest() throws Exception {
+        String since = null;
+
+        /** no revoked certs */
+
+        // clear revoked certs
+        TestUtil.clearRevokedCerts(jt);
+
+        // get next revocation list batch
+        MockHttpServletResponse response = getNextRevocationListBatch(since);
+
+        // verify response
+        assertRevocationListBatchResponse(
+                response,
+                0,
+                true,
+                "0",
+                CacheUtil.roundToNextRevocationRetentionBucketStart(Instant.now()));
+
+        /** imported revoked certs (all released) */
+
+        // import revoked certs
+        int releasedRevokedCertCount = 20;
+        revokedCertDataService.replaceRevokedCerts(
+                TestUtil.getRevokedCertUvcis(releasedRevokedCertCount));
+
+        // release certs
+        TestUtil.releaseRevokedCerts(jt, Instant.now());
+
+        // get next revocation list batch
+        response = getNextRevocationListBatch(since);
+
+        // verify response
+        assertRevocationListBatchResponse(
+                response,
+                releasedRevokedCertCount,
+                true,
+                null,
+                CacheUtil.roundToNextRevocationRetentionBucketStart(Instant.now()));
+        String nextSince = response.getHeader(NEXT_SINCE_HEADER);
+
+        /** imported additional revoked certs (new not released yet) */
+
+        // import with new (unreleased) revoked certs
+        int newRevokedCertCount = 10;
+        revokedCertDataService.replaceRevokedCerts(
+                TestUtil.getRevokedCertUvcis(releasedRevokedCertCount + newRevokedCertCount));
+
+        // get next revocation list batch
+        response = getNextRevocationListBatch(since);
+
+        // verify response (unchanged)
+        assertRevocationListBatchResponse(
+                response,
+                releasedRevokedCertCount,
+                true,
+                nextSince,
+                CacheUtil.roundToNextRevocationRetentionBucketStart(Instant.now()));
+
+        /** release new certs */
+
+        // release certs
+        TestUtil.releaseRevokedCerts(jt, Instant.now());
+        releasedRevokedCertCount += newRevokedCertCount;
+
+        // get next revocation list batch
+        response = getNextRevocationListBatch(since);
+
+        // verify response
+        assertRevocationListBatchResponse(
+                response,
+                releasedRevokedCertCount,
+                true,
+                String.valueOf(Long.parseLong(nextSince) + newRevokedCertCount),
+                CacheUtil.roundToNextRevocationRetentionBucketStart(Instant.now()));
+
+        /** test batching */
+
+        // import and release
+        int batchSize = revokedCertDataService.getRevokedCertBatchSize();
+        int batchCount = 4;
+        releasedRevokedCertCount = batchSize * batchCount;
+        revokedCertDataService.replaceRevokedCerts(
+                TestUtil.getRevokedCertUvcis(releasedRevokedCertCount));
+        TestUtil.releaseRevokedCerts(jt, Instant.now());
+
+        // fetch and assert
+        for (int i = 1; i <= batchCount; i++) {
+            // get next revocation list batch
+            response = getNextRevocationListBatch(since);
+            // verify response (unchanged)
+            assertRevocationListBatchResponse(
+                    response,
+                    batchSize,
+                    i == batchCount,
+                    since != null ? String.valueOf(Long.parseLong(since) + batchSize) : null,
+                    CacheUtil.roundToNextRevocationRetentionBucketStart(Instant.now()));
+            since = response.getHeader(NEXT_SINCE_HEADER);
+        }
+    }
+
+    private MockHttpServletResponse getNextRevocationListBatch(String since) throws Exception {
+        return mockMvc.perform(
+                        get(revocationListUrl)
+                                .queryParam(SINCE_QUERY_PARAM, since)
+                                .accept(acceptMediaType))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn()
+                .getResponse();
+    }
+
+    private void assertRevocationListBatchResponse(
+            MockHttpServletResponse response,
+            int expectedSize,
+            boolean expectedUpToDate,
+            String expectedNextSinceHeader,
+            Instant expectedExpire)
+            throws JsonProcessingException, UnsupportedEncodingException {
+        assertNotNull(response);
+
+        RevocationResponse revocationList =
+                testHelper.verifyAndReadValue(
+                        response,
+                        acceptMediaType,
+                        TestHelper.PATH_TO_CA_PEM,
+                        RevocationResponse.class);
+        assertNotNull(revocationList.getRevokedCerts());
+        assertEquals(expectedSize, revocationList.getRevokedCerts().size());
+
+        assertHeaders(response, expectedUpToDate, expectedNextSinceHeader, expectedExpire);
+    }
+
+    private void assertHeaders(
+            MockHttpServletResponse response,
+            boolean expectedUpToDate,
+            String expectedNextSinceHeader,
+            Instant expectedExpires) {
+        assertEquals(expectedUpToDate ? "true" : "false", response.getHeader(UP_TO_DATE_HEADER));
+        if (expectedNextSinceHeader != null) {
+            assertEquals(expectedNextSinceHeader, response.getHeader(NEXT_SINCE_HEADER));
+        }
+        assertExpires(response, expectedExpires);
+    }
+
+    private void assertExpires(MockHttpServletResponse response, Instant expectedExpires) {
+        assertEquals(
+                CacheUtil.formatHeaderDate(expectedExpires), response.getHeader(EXPIRES_HEADER));
+    }
+
+    @Override
+    protected String getUrlForSecurityHeadersTest() {
+        return revocationListUrl;
+    }
+
+    @Test
+    @Override
+    public void testSecurityHeaders() throws Exception {
+        super.testSecurityHeaders();
+    }
+
+    @Override
+    protected MediaType getSecurityHeadersRequestMediaType() {
+        return this.acceptMediaType;
+    }
+}

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/RevocationListV2ControllerJsonTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/RevocationListV2ControllerJsonTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package ch.admin.bag.covidcertificate.backend.verifier.ws.controller;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles({"actuator-security"})
+@SpringBootTest(
+        properties = {
+            "ws.monitor.prometheus.user=prometheus",
+            "ws.monitor.prometheus.password=prometheus",
+            "management.endpoints.enabled-by-default=true",
+            "management.endpoints.web.exposure.include=*"
+        })
+@TestInstance(Lifecycle.PER_CLASS)
+public class RevocationListV2ControllerJsonTest extends RevocationListControllerV2Test {
+
+    @BeforeAll
+    public void setup() {
+        this.acceptMediaType = MediaType.APPLICATION_JSON;
+        super.setup();
+    }
+}


### PR DESCRIPTION
this pull request adds improved cacheability for the revocation list v2 request. by delaying the release of the latest revoked certs (with retention buckets), the number of distinct `next-since` headers is reduced, thus reducing the number of requests that need to be cached.