### PR TITLE
business rules: extend validity of J&J vaccinations to 21+365 days

### DIFF
--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/CH/VR-CH-0005/rule.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/CH/VR-CH-0005/rule.json
@@ -9,7 +9,7 @@
   "Country": "CH",
   "Description": [
     {
-      "desc": "If the vaccine requires one dose, and only one dose was administered, it is valid after 21 days ",
+      "desc": "If the vaccine requires one dose, and only one dose was administered, it is valid after 21 days and until 387 days later",
       "lang": "en"
     }
   ],
@@ -46,23 +46,49 @@
             ]
           },
           {
-            "not-before": [
+            "and": [
               {
-                "plusTime": [
+                "not-before": [
                   {
-                    "var": "external.validationClock"
+                    "plusTime": [
+                      {
+                        "var": "external.validationClock"
+                      },
+                      0,
+                      "day"
+                    ]
                   },
-                  0,
-                  "day"
+                  {
+                    "plusTime": [
+                      {
+                        "var": "payload.v.0.dt"
+                      },
+                      21,
+                      "day"
+                    ]
+                  }
                 ]
               },
               {
-                "plusTime": [
+                "before": [
                   {
-                    "var": "payload.v.0.dt"
+                    "plusTime": [
+                      {
+                        "var": "external.validationClock"
+                      },
+                      0,
+                      "day"
+                    ]
                   },
-                  21,
-                  "day"
+                  {
+                    "plusTime": [
+                      {
+                        "var": "payload.v.0.dt"
+                      },
+                      387,
+                      "day"
+                    ]
+                  }
                 ]
               }
             ]

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/CH/VR-CH-0006/rule.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/CH/VR-CH-0006/rule.json
@@ -1,13 +1,14 @@
 {
   "AffectedFields": [
     "v.0",
-    "v.0.dt"
+    "v.0.dt",
+    "v.0.mp"
   ],
   "CertificateType": "Vaccination",
   "Country": "CH",
   "Description": [
     {
-      "desc": "Today must be less than the vaccination date plus 364 days",
+      "desc": "Today must be less than the vaccination date plus 364 days for 2-dose vaccines",
       "lang": "en"
     }
   ],
@@ -17,7 +18,25 @@
   "Logic": {
     "if": [
       {
-        "var": "payload.v.0"
+        "and": [
+          {
+            "var": "payload.v.0"
+          },
+          {
+            "!": [
+              {
+                "in": [
+                  {
+                    "var": "payload.v.0.mp"
+                  },
+                  [
+                    "EU/1/20/1525"
+                  ]
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
         "before": [

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/CH/VR-CH-0007/rule.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/CH/VR-CH-0007/rule.json
@@ -9,7 +9,7 @@
   "Country": "CH",
   "Description": [
     {
-      "desc": "If the vaccine requires only one dose but more than one dose was administered, it is valid from today ",
+      "desc": "If the vaccine requires only one dose but more than one dose was administered, it is valid from today for 365 days",
       "lang": "en"
     }
   ],
@@ -46,23 +46,49 @@
             ]
           },
           {
-            "not-before": [
+            "and": [
               {
-                "plusTime": [
+                "not-before": [
                   {
-                    "var": "external.validationClock"
+                    "plusTime": [
+                      {
+                        "var": "external.validationClock"
+                      },
+                      0,
+                      "day"
+                    ]
                   },
-                  0,
-                  "day"
+                  {
+                    "plusTime": [
+                      {
+                        "var": "payload.v.0.dt"
+                      },
+                      0,
+                      "day"
+                    ]
+                  }
                 ]
               },
               {
-                "plusTime": [
+                "before": [
                   {
-                    "var": "payload.v.0.dt"
+                    "plusTime": [
+                      {
+                        "var": "external.validationClock"
+                      },
+                      0,
+                      "day"
+                    ]
                   },
-                  0,
-                  "day"
+                  {
+                    "plusTime": [
+                      {
+                        "var": "payload.v.0.dt"
+                      },
+                      365,
+                      "day"
+                    ]
+                  }
                 ]
               }
             ]

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/verificationRules.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/verificationRules.json
@@ -236,7 +236,7 @@
     },
     {
       "inputParameter": "[\"v.0\",\"v.0.mp\",\"v.0.dn\",\"v.0.dt\"]",
-      "description": "If the vaccine requires one dose, and only one dose was administered, it is valid after 21 days ",
+      "description": "If the vaccine requires one dose, and only one dose was administered, it is valid after 21 days and until 387 days later",
       "id": "VR-CH-0005",
       "logic": {
         "if": [
@@ -268,23 +268,49 @@
                 ]
               },
               {
-                ">=": [
+                "and": [
                   {
-                    "plusTime": [
+                    ">=": [
                       {
-                        "var": "external.validationClock"
+                        "plusTime": [
+                          {
+                            "var": "external.validationClock"
+                          },
+                          0,
+                          "day"
+                        ]
                       },
-                      0,
-                      "day"
+                      {
+                        "plusTime": [
+                          {
+                            "var": "payload.v.0.dt"
+                          },
+                          21,
+                          "day"
+                        ]
+                      }
                     ]
                   },
                   {
-                    "plusTime": [
+                    "<": [
                       {
-                        "var": "payload.v.0.dt"
+                        "plusTime": [
+                          {
+                            "var": "external.validationClock"
+                          },
+                          0,
+                          "day"
+                        ]
                       },
-                      21,
-                      "day"
+                      {
+                        "plusTime": [
+                          {
+                            "var": "payload.v.0.dt"
+                          },
+                          387,
+                          "day"
+                        ]
+                      }
                     ]
                   }
                 ]
@@ -297,13 +323,31 @@
       }
     },
     {
-      "inputParameter": "[\"v.0\",\"v.0.dt\"]",
-      "description": "Today must be less than the vaccination date plus 364 days",
+      "inputParameter": "[\"v.0\",\"v.0.dt\",\"v.0.mp\"]",
+      "description": "Today must be less than the vaccination date plus 364 days for 2-dose vaccines",
       "id": "VR-CH-0006",
       "logic": {
         "if": [
           {
-            "var": "payload.v.0"
+            "and": [
+              {
+                "var": "payload.v.0"
+              },
+              {
+                "!": [
+                  {
+                    "in": [
+                      {
+                        "var": "payload.v.0.mp"
+                      },
+                      [
+                        "EU/1/20/1525"
+                      ]
+                    ]
+                  }
+                ]
+              }
+            ]
           },
           {
             "<": [
@@ -333,7 +377,7 @@
     },
     {
       "inputParameter": "[\"v.0\",\"v.0.mp\",\"v.0.dn\",\"v.0.dt\"]",
-      "description": "If the vaccine requires only one dose but more than one dose was administered, it is valid from today ",
+      "description": "If the vaccine requires only one dose but more than one dose was administered, it is valid from today for 365 days",
       "id": "VR-CH-0007",
       "logic": {
         "if": [
@@ -365,23 +409,49 @@
                 ]
               },
               {
-                ">=": [
+                "and": [
                   {
-                    "plusTime": [
+                    ">=": [
                       {
-                        "var": "external.validationClock"
+                        "plusTime": [
+                          {
+                            "var": "external.validationClock"
+                          },
+                          0,
+                          "day"
+                        ]
                       },
-                      0,
-                      "day"
+                      {
+                        "plusTime": [
+                          {
+                            "var": "payload.v.0.dt"
+                          },
+                          0,
+                          "day"
+                        ]
+                      }
                     ]
                   },
                   {
-                    "plusTime": [
+                    "<": [
                       {
-                        "var": "payload.v.0.dt"
+                        "plusTime": [
+                          {
+                            "var": "external.validationClock"
+                          },
+                          0,
+                          "day"
+                        ]
                       },
-                      0,
-                      "day"
+                      {
+                        "plusTime": [
+                          {
+                            "var": "payload.v.0.dt"
+                          },
+                          365,
+                          "day"
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/verificationRulesMaster.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/verificationRulesMaster.json
@@ -536,7 +536,7 @@
       "country": "CH",
       "description": [
         {
-          "desc": "If the vaccine requires one dose, and only one dose was administered, it is valid after 21 days ",
+          "desc": "If the vaccine requires one dose, and only one dose was administered, it is valid after 21 days and until 387 days later",
           "lang": "en"
         }
       ],
@@ -573,23 +573,49 @@
                 ]
               },
               {
-                "not-before": [
+                "and": [
                   {
-                    "plusTime": [
+                    "not-before": [
                       {
-                        "var": "external.validationClock"
+                        "plusTime": [
+                          {
+                            "var": "external.validationClock"
+                          },
+                          0,
+                          "day"
+                        ]
                       },
-                      0,
-                      "day"
+                      {
+                        "plusTime": [
+                          {
+                            "var": "payload.v.0.dt"
+                          },
+                          21,
+                          "day"
+                        ]
+                      }
                     ]
                   },
                   {
-                    "plusTime": [
+                    "before": [
                       {
-                        "var": "payload.v.0.dt"
+                        "plusTime": [
+                          {
+                            "var": "external.validationClock"
+                          },
+                          0,
+                          "day"
+                        ]
                       },
-                      21,
-                      "day"
+                      {
+                        "plusTime": [
+                          {
+                            "var": "payload.v.0.dt"
+                          },
+                          387,
+                          "day"
+                        ]
+                      }
                     ]
                   }
                 ]
@@ -609,13 +635,14 @@
     {
       "affectedFields": [
         "v.0",
-        "v.0.dt"
+        "v.0.dt",
+        "v.0.mp"
       ],
       "certificateType": "Vaccination",
       "country": "CH",
       "description": [
         {
-          "desc": "Today must be less than the vaccination date plus 364 days",
+          "desc": "Today must be less than the vaccination date plus 364 days for 2-dose vaccines",
           "lang": "en"
         }
       ],
@@ -625,7 +652,25 @@
       "logic": {
         "if": [
           {
-            "var": "payload.v.0"
+            "and": [
+              {
+                "var": "payload.v.0"
+              },
+              {
+                "!": [
+                  {
+                    "in": [
+                      {
+                        "var": "payload.v.0.mp"
+                      },
+                      [
+                        "EU/1/20/1525"
+                      ]
+                    ]
+                  }
+                ]
+              }
+            ]
           },
           {
             "before": [
@@ -669,7 +714,7 @@
       "country": "CH",
       "description": [
         {
-          "desc": "If the vaccine requires only one dose but more than one dose was administered, it is valid from today ",
+          "desc": "If the vaccine requires only one dose but more than one dose was administered, it is valid from today for 365 days",
           "lang": "en"
         }
       ],
@@ -706,23 +751,49 @@
                 ]
               },
               {
-                "not-before": [
+                "and": [
                   {
-                    "plusTime": [
+                    "not-before": [
                       {
-                        "var": "external.validationClock"
+                        "plusTime": [
+                          {
+                            "var": "external.validationClock"
+                          },
+                          0,
+                          "day"
+                        ]
                       },
-                      0,
-                      "day"
+                      {
+                        "plusTime": [
+                          {
+                            "var": "payload.v.0.dt"
+                          },
+                          0,
+                          "day"
+                        ]
+                      }
                     ]
                   },
                   {
-                    "plusTime": [
+                    "before": [
                       {
-                        "var": "payload.v.0.dt"
+                        "plusTime": [
+                          {
+                            "var": "external.validationClock"
+                          },
+                          0,
+                          "day"
+                        ]
                       },
-                      0,
-                      "day"
+                      {
+                        "plusTime": [
+                          {
+                            "var": "payload.v.0.dt"
+                          },
+                          365,
+                          "day"
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/verificationRulesUpload.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/verificationRulesUpload.json
@@ -367,7 +367,7 @@
       "Country": "CH",
       "Description": [
         {
-          "desc": "If the vaccine requires one dose, and only one dose was administered, it is valid after 21 days ",
+          "desc": "If the vaccine requires one dose, and only one dose was administered, it is valid after 21 days and until 387 days later",
           "lang": "en"
         }
       ],
@@ -404,23 +404,49 @@
                 ]
               },
               {
-                "not-before": [
+                "and": [
                   {
-                    "plusTime": [
+                    "not-before": [
                       {
-                        "var": "external.validationClock"
+                        "plusTime": [
+                          {
+                            "var": "external.validationClock"
+                          },
+                          0,
+                          "day"
+                        ]
                       },
-                      0,
-                      "day"
+                      {
+                        "plusTime": [
+                          {
+                            "var": "payload.v.0.dt"
+                          },
+                          21,
+                          "day"
+                        ]
+                      }
                     ]
                   },
                   {
-                    "plusTime": [
+                    "before": [
                       {
-                        "var": "payload.v.0.dt"
+                        "plusTime": [
+                          {
+                            "var": "external.validationClock"
+                          },
+                          0,
+                          "day"
+                        ]
                       },
-                      21,
-                      "day"
+                      {
+                        "plusTime": [
+                          {
+                            "var": "payload.v.0.dt"
+                          },
+                          387,
+                          "day"
+                        ]
+                      }
                     ]
                   }
                 ]
@@ -442,13 +468,14 @@
     {
       "AffectedFields": [
         "v.0",
-        "v.0.dt"
+        "v.0.dt",
+        "v.0.mp"
       ],
       "CertificateType": "Vaccination",
       "Country": "CH",
       "Description": [
         {
-          "desc": "Today must be less than the vaccination date plus 364 days",
+          "desc": "Today must be less than the vaccination date plus 364 days for 2-dose vaccines",
           "lang": "en"
         }
       ],
@@ -458,7 +485,25 @@
       "Logic": {
         "if": [
           {
-            "var": "payload.v.0"
+            "and": [
+              {
+                "var": "payload.v.0"
+              },
+              {
+                "!": [
+                  {
+                    "in": [
+                      {
+                        "var": "payload.v.0.mp"
+                      },
+                      [
+                        "EU/1/20/1525"
+                      ]
+                    ]
+                  }
+                ]
+              }
+            ]
           },
           {
             "before": [
@@ -504,7 +549,7 @@
       "Country": "CH",
       "Description": [
         {
-          "desc": "If the vaccine requires only one dose but more than one dose was administered, it is valid from today ",
+          "desc": "If the vaccine requires only one dose but more than one dose was administered, it is valid from today for 365 days",
           "lang": "en"
         }
       ],
@@ -541,23 +586,49 @@
                 ]
               },
               {
-                "not-before": [
+                "and": [
                   {
-                    "plusTime": [
+                    "not-before": [
                       {
-                        "var": "external.validationClock"
+                        "plusTime": [
+                          {
+                            "var": "external.validationClock"
+                          },
+                          0,
+                          "day"
+                        ]
                       },
-                      0,
-                      "day"
+                      {
+                        "plusTime": [
+                          {
+                            "var": "payload.v.0.dt"
+                          },
+                          0,
+                          "day"
+                        ]
+                      }
                     ]
                   },
                   {
-                    "plusTime": [
+                    "before": [
                       {
-                        "var": "payload.v.0.dt"
+                        "plusTime": [
+                          {
+                            "var": "external.validationClock"
+                          },
+                          0,
+                          "day"
+                        ]
                       },
-                      0,
-                      "day"
+                      {
+                        "plusTime": [
+                          {
+                            "var": "payload.v.0.dt"
+                          },
+                          365,
+                          "day"
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/verificationRulesV2.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/verificationRulesV2.json
@@ -536,7 +536,7 @@
       "country": "CH",
       "description": [
         {
-          "desc": "If the vaccine requires one dose, and only one dose was administered, it is valid after 21 days ",
+          "desc": "If the vaccine requires one dose, and only one dose was administered, it is valid after 21 days and until 387 days later",
           "lang": "en"
         }
       ],
@@ -573,23 +573,49 @@
                 ]
               },
               {
-                "not-before": [
+                "and": [
                   {
-                    "plusTime": [
+                    "not-before": [
                       {
-                        "var": "external.validationClock"
+                        "plusTime": [
+                          {
+                            "var": "external.validationClock"
+                          },
+                          0,
+                          "day"
+                        ]
                       },
-                      0,
-                      "day"
+                      {
+                        "plusTime": [
+                          {
+                            "var": "payload.v.0.dt"
+                          },
+                          21,
+                          "day"
+                        ]
+                      }
                     ]
                   },
                   {
-                    "plusTime": [
+                    "before": [
                       {
-                        "var": "payload.v.0.dt"
+                        "plusTime": [
+                          {
+                            "var": "external.validationClock"
+                          },
+                          0,
+                          "day"
+                        ]
                       },
-                      21,
-                      "day"
+                      {
+                        "plusTime": [
+                          {
+                            "var": "payload.v.0.dt"
+                          },
+                          387,
+                          "day"
+                        ]
+                      }
                     ]
                   }
                 ]
@@ -609,13 +635,14 @@
     {
       "affectedFields": [
         "v.0",
-        "v.0.dt"
+        "v.0.dt",
+        "v.0.mp"
       ],
       "certificateType": "Vaccination",
       "country": "CH",
       "description": [
         {
-          "desc": "Today must be less than the vaccination date plus 364 days",
+          "desc": "Today must be less than the vaccination date plus 364 days for 2-dose vaccines",
           "lang": "en"
         }
       ],
@@ -625,7 +652,25 @@
       "logic": {
         "if": [
           {
-            "var": "payload.v.0"
+            "and": [
+              {
+                "var": "payload.v.0"
+              },
+              {
+                "!": [
+                  {
+                    "in": [
+                      {
+                        "var": "payload.v.0.mp"
+                      },
+                      [
+                        "EU/1/20/1525"
+                      ]
+                    ]
+                  }
+                ]
+              }
+            ]
           },
           {
             "before": [
@@ -669,7 +714,7 @@
       "country": "CH",
       "description": [
         {
-          "desc": "If the vaccine requires only one dose but more than one dose was administered, it is valid from today ",
+          "desc": "If the vaccine requires only one dose but more than one dose was administered, it is valid from today for 365 days",
           "lang": "en"
         }
       ],
@@ -706,23 +751,49 @@
                 ]
               },
               {
-                "not-before": [
+                "and": [
                   {
-                    "plusTime": [
+                    "not-before": [
                       {
-                        "var": "external.validationClock"
+                        "plusTime": [
+                          {
+                            "var": "external.validationClock"
+                          },
+                          0,
+                          "day"
+                        ]
                       },
-                      0,
-                      "day"
+                      {
+                        "plusTime": [
+                          {
+                            "var": "payload.v.0.dt"
+                          },
+                          0,
+                          "day"
+                        ]
+                      }
                     ]
                   },
                   {
-                    "plusTime": [
+                    "before": [
                       {
-                        "var": "payload.v.0.dt"
+                        "plusTime": [
+                          {
+                            "var": "external.validationClock"
+                          },
+                          0,
+                          "day"
+                        ]
                       },
-                      0,
-                      "day"
+                      {
+                        "plusTime": [
+                          {
+                            "var": "payload.v.0.dt"
+                          },
+                          365,
+                          "day"
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/EtagUtilTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/EtagUtilTest.java
@@ -41,7 +41,7 @@ public class EtagUtilTest {
 
     @Test
     public void testFileHash() throws Exception {
-        String expected = "W/\"4df12cb27185dde3d608855133862e8808fa8840\"";
+        String expected = "W/\"f487a90772597c52fa13a82d5a687946380be93f\"";
         String sha1 = EtagUtil.getSha1HashForFiles(true, PATH_TO_VERIFICATION_RULES);
         assertEquals(expected, sha1);
         assertNotEquals(


### PR DESCRIPTION
Calculate the end of validity for J&J vaccines as 365 days from the beginning of its validity (after 21st day) rather than from date of vaccination