### PR TITLE
don't specify explicit password encoder for actuator security

### DIFF
--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-sync/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/sync/config/ActuatorSecurity.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-sync/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/sync/config/ActuatorSecurity.java
@@ -26,8 +26,6 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 @Order(Ordered.HIGHEST_PRECEDENCE + 9)
@@ -84,12 +82,7 @@ public class ActuatorSecurity extends WebSecurityConfigurerAdapter {
             throws Exception {
         auth.inMemoryAuthentication()
                 .withUser(securityConfig.getUsername())
-                .password(passwordEncoder().encode(securityConfig.getPassword()))
+                .password(securityConfig.getPassword())
                 .roles(PROMETHEUS_ROLE);
-    }
-
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
     }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/ActuatorSecurity.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/ActuatorSecurity.java
@@ -26,8 +26,6 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 @Order(Ordered.HIGHEST_PRECEDENCE + 9)
@@ -84,12 +82,7 @@ public class ActuatorSecurity extends WebSecurityConfigurerAdapter {
             throws Exception {
         auth.inMemoryAuthentication()
                 .withUser(securityConfig.getUsername())
-                .password(passwordEncoder().encode(securityConfig.getPassword()))
+                .password(securityConfig.getPassword())
                 .roles(PROMETHEUS_ROLE);
-    }
-
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
     }
 }


### PR DESCRIPTION
this pull request ensures that the specified password encoder (https://spring.io/blog/2017/11/01/spring-security-5-0-0-rc1-released#password-encoding) is used instead of bcrypt