### PR TITLE
[WIP] Feature: Improve caching

### DIFF
--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/util/CacheUtil.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/util/CacheUtil.java
@@ -26,6 +26,8 @@ public class CacheUtil {
 
     public static Duration KEYS_BUCKET_DURATION;
     public static Duration REVOCATION_RETENTION_BUCKET_DURATION;
+    public static Duration VERIFICATION_RULES_BUCKET_DURATION;
+
 
     private CacheUtil() {}
 
@@ -75,5 +77,9 @@ public class CacheUtil {
 
     public static Instant roundToPreviousRevocationRetentionBucketStart(Instant now) {
         return roundToPreviousBucketStart(now, CacheUtil.REVOCATION_RETENTION_BUCKET_DURATION);
+    }
+
+    public static Instant roundToNextVerificationRulesBucketStart(Instant now) {
+        return roundToNextBucketStart(now, CacheUtil.VERIFICATION_RULES_BUCKET_DURATION);
     }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-model/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/model/cert/ActiveCertsResponse.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-model/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/model/cert/ActiveCertsResponse.java
@@ -24,13 +24,17 @@ public class ActiveCertsResponse {
             example = "172800000")
     private Duration validDuration = Duration.ofHours(48);
 
+    @Documentation(description = "up to which key id can be requested")
+    private Long upTo;
+
     public ActiveCertsResponse() {}
 
-    public ActiveCertsResponse(List<String> activeKeyIds) {
+    public ActiveCertsResponse(List<String> activeKeyIds, Long upTo) {
         if (activeKeyIds == null) {
             activeKeyIds = new ArrayList<>();
         }
         this.activeKeyIds = activeKeyIds;
+        this.upTo = upTo;
     }
 
     public List<String> getActiveKeyIds() {
@@ -47,5 +51,13 @@ public class ActiveCertsResponse {
 
     public void setValidDuration(Long durationInMs) {
         this.validDuration = Duration.ofMillis(durationInMs);
+    }
+
+    public Long getUpTo() {
+        return upTo;
+    }
+
+    public void setUpTo(Long upTo) {
+        this.upTo = upTo;
     }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/WsBaseConfig.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/WsBaseConfig.java
@@ -105,6 +105,11 @@ public abstract class WsBaseConfig implements WebMvcConfigurer {
         CacheUtil.VERIFICATION_RULES_MAX_AGE = maxAge;
     }
 
+    @Value("${ws.verificationRules.release-bucket-duration:PT6H}")
+    public void setVerificationRulesBucketDuration(Duration bucketDuration) {
+        CacheUtil.VERIFICATION_RULES_BUCKET_DURATION = bucketDuration;
+    }
+
     @Value("${ws.valueSets.max-age:PT1M}")
     public void setValueSetsMaxAge(Duration maxAge) {
         CacheUtil.VALUE_SETS_MAX_AGE = maxAge;

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/WsBaseConfig.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/WsBaseConfig.java
@@ -85,7 +85,7 @@ public abstract class WsBaseConfig implements WebMvcConfigurer {
 
     public abstract Flyway flyway();
 
-    @Value("${ws.keys.release-bucket-duration:PT1H}")
+    @Value("${ws.keys.release-bucket-duration:PT6H}")
     public void setKeysBucketDuration(Duration bucketDuration) {
         CacheUtil.KEYS_BUCKET_DURATION = bucketDuration;
     }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/KeyControllerV2.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/KeyControllerV2.java
@@ -19,6 +19,7 @@ import ch.admin.bag.covidcertificate.backend.verifier.model.cert.ClientCert;
 import ch.admin.bag.covidcertificate.backend.verifier.ws.utils.EtagUtil;
 import ch.ubique.openapi.docannotations.Documentation;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import org.springframework.http.CacheControl;
 import org.springframework.http.HttpHeaders;
@@ -107,9 +108,10 @@ public class KeyControllerV2 {
         Instant now = Instant.now();
         long maxDscPkId = verifierDataService.findMaxDscPkId();
         List<String> activeKeyIds = verifierDataService.findActiveDscKeyIds();
-
+        List<String> etagComponents = new ArrayList<>(activeKeyIds);
+        etagComponents.add(String.valueOf(maxDscPkId));
         // check etag
-        String currentEtag = EtagUtil.getUnsortedListEtag(true, activeKeyIds);
+        String currentEtag = EtagUtil.getUnsortedListEtag(true, etagComponents);
         if (request.checkNotModified(currentEtag)) {
             return ResponseEntity.status(HttpStatus.NOT_MODIFIED).build();
         }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/KeyControllerV2.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/KeyControllerV2.java
@@ -116,7 +116,7 @@ public class KeyControllerV2 {
 
         return ResponseEntity.ok()
                 .headers(getKeysListHeaders(maxDscPkId, now))
-                .body(new ActiveCertsResponse(activeKeyIds));
+                .body(new ActiveCertsResponse(activeKeyIds, maxDscPkId));
     }
 
     private HttpHeaders getKeysListHeaders(Long upTo, Instant now) {


### PR DESCRIPTION
This pull-request improves caching of the trustlist requested by the SDK/apps:

- [X] Release new keys/rules/revocation lists synchronized every 6h (00,06,12,18 UTC) and instruct CDN to cache them until next release. This will not only improve the cache-hit ratio but also improve fault tolerance of the origin. 
- [X] Move "upTo" information of /trust/v2/keys/list to HTTP body to avoid HTTP body/header mismatch situations on CDN
- [x] Add `maxDscPkId` to Etag generation of /trust/v2/keys requests
 