### PR TITLE
fix display-from-date for tourist vaccine

### DIFF
--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/verificationRulesMaster.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/verificationRulesMaster.json
@@ -77,7 +77,13 @@
                         ]
                       },
                       {
-                        "var": "undefined"
+                        "plusTime": [
+                          {
+                            "var": "external.validationClock"
+                          },
+                          0,
+                          "day"
+                        ]
                       }
                     ]
                   },
@@ -236,7 +242,48 @@
                         ]
                       },
                       {
-                        "var": "undefined"
+                        "if": [
+                          {
+                            "before": [
+                              {
+                                "plusTime": [
+                                  {
+                                    "var": "payload.v.0.dt"
+                                  },
+                                  364,
+                                  "day"
+                                ]
+                              },
+                              {
+                                "plusTime": [
+                                  {
+                                    "var": "external.validationClock"
+                                  },
+                                  0,
+                                  "day"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "plusTime": [
+                              {
+                                "var": "payload.v.0.dt"
+                              },
+                              364,
+                              "day"
+                            ]
+                          },
+                          {
+                            "plusTime": [
+                              {
+                                "var": "external.validationClock"
+                              }v,
+                              1,
+                              "day"
+                            ]
+                          }
+                        ]
                       }
                     ]
                   },

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/verificationRulesMaster.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/verificationRulesMaster.json
@@ -65,12 +65,12 @@
                   {
                     "if": [
                       {
-                        "var": "payload.h.exp"
+                        "var": "payload.h.iat"
                       },
                       {
                         "plusTime": [
                           {
-                            "var": "payload.h.exp"
+                            "var": "payload.h.iat"
                           },
                           0,
                           "day"

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/verificationRulesMaster.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/verificationRulesMaster.json
@@ -278,7 +278,7 @@
                             "plusTime": [
                               {
                                 "var": "external.validationClock"
-                              }v,
+                              },
                               1,
                               "day"
                             ]

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/verificationRulesV2.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/verificationRulesV2.json
@@ -126,7 +126,13 @@
                         ]
                       },
                       {
-                        "var": "undefined"
+                        "plusTime": [
+                          {
+                            "var": "external.validationClock"
+                          },
+                          0,
+                          "day"
+                        ]
                       }
                     ]
                   },
@@ -285,7 +291,48 @@
                         ]
                       },
                       {
-                        "var": "undefined"
+                        "if": [
+                          {
+                            "before": [
+                              {
+                                "plusTime": [
+                                  {
+                                    "var": "payload.v.0.dt"
+                                  },
+                                  364,
+                                  "day"
+                                ]
+                              },
+                              {
+                                "plusTime": [
+                                  {
+                                    "var": "external.validationClock"
+                                  },
+                                  0,
+                                  "day"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "plusTime": [
+                              {
+                                "var": "payload.v.0.dt"
+                              },
+                              364,
+                              "day"
+                            ]
+                          },
+                          {
+                            "plusTime": [
+                              {
+                                "var": "external.validationClock"
+                              },
+                              1,
+                              "day"
+                            ]
+                          }
+                        ]
                       }
                     ]
                   },

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/verificationRulesV2.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/verificationRulesV2.json
@@ -114,12 +114,12 @@
                   {
                     "if": [
                       {
-                        "var": "payload.h.exp"
+                        "var": "payload.h.iat"
                       },
                       {
                         "plusTime": [
                           {
-                            "var": "payload.h.exp"
+                            "var": "payload.h.iat"
                           },
                           0,
                           "day"


### PR DESCRIPTION
- Fixes the display-from-date display rule for tourist vaccine certs by changing v.0.payload.ext to v.0.payload.iat﻿  
- Adds fallback from-date and to-date for older SDK versions