### PR TITLE
tag prereleases on github

### DIFF
--- a/.github/workflows/tagged_release.yaml
+++ b/.github/workflows/tagged_release.yaml
@@ -35,7 +35,7 @@ jobs:
       uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        prerelease: false
+        prerelease: ${{ contains(github.ref, 'prerelease') }}
         files: |
           ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-sync/target/ch-covidcertificate-backend-verifier-sync.jar
           ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-sync/target/ch-covidcertificate-backend-verifier-sync.jar.sha256


### PR DESCRIPTION
Correctly sets the prerelease tag in the action that creates a Github release