### PR TITLE
implement 90 day exemption for 2G+

### DIFF
--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/generated/mode-rules/modeRules.aifc.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/generated/mode-rules/modeRules.aifc.json
@@ -83,30 +83,38 @@
                       ]
                     },
                     {
-                      "!": [
-                        {
-                          "and": [
-                            {
-                              "!": [
-                                {
-                                  "var": "payload.v.0"
-                                }
-                              ]
-                            },
-                            {
-                              "!": [
-                                {
-                                  "var": "payload.r.0"
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      ]
+                      "var": "payload.v.0"
                     }
                   ]
                 },
-                "SUCCESS_2G",
+                {
+                  "if": [
+                    {
+                      "not-after": [
+                        {
+                          "plusTime": [
+                            {
+                              "var": "external.validationClock"
+                            },
+                            0,
+                            "day"
+                          ]
+                        },
+                        {
+                          "plusTime": [
+                            {
+                              "var": "payload.v.0.dt"
+                            },
+                            90,
+                            "day"
+                          ]
+                        }
+                      ]
+                    },
+                    "SUCCESS",
+                    "SUCCESS_2G"
+                  ]
+                },
                 {
                   "if": [
                     {
@@ -120,24 +128,55 @@
                           ]
                         },
                         {
-                          "var": "payload.t.0"
+                          "var": "payload.r.0"
                         }
                       ]
                     },
                     {
                       "if": [
                         {
-                          "in": [
+                          "not-after": [
                             {
-                              "var": "payload.t.0.tt"
+                              "plusTime": [
+                                {
+                                  "var": "external.validationClock"
+                                },
+                                0,
+                                "day"
+                              ]
                             },
-                            [
-                              "LP6464-4",
-                              "LP217198-3"
-                            ]
+                            {
+                              "plusTime": [
+                                {
+                                  "var": "payload.r.0.fr"
+                                },
+                                90,
+                                "day"
+                              ]
+                            }
                           ]
                         },
-                        "SUCCESS_2G_PLUS",
+                        "SUCCESS",
+                        "SUCCESS_2G"
+                      ]
+                    },
+                    {
+                      "if": [
+                        {
+                          "and": [
+                            {
+                              "===": [
+                                {
+                                  "var": "payload.h.mode"
+                                },
+                                "TWO_G_PLUS"
+                              ]
+                            },
+                            {
+                              "var": "payload.t.0"
+                            }
+                          ]
+                        },
                         {
                           "if": [
                             {
@@ -146,28 +185,44 @@
                                   "var": "payload.t.0.tt"
                                 },
                                 [
-                                  "94504-8"
+                                  "LP6464-4",
+                                  "LP217198-3"
                                 ]
                               ]
                             },
-                            "SUCCESS_2G",
-                            "INVALID"
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "if": [
-                        {
-                          "===": [
+                            "SUCCESS_2G_PLUS",
                             {
-                              "var": "payload.h.mode"
-                            },
-                            "TWO_G_PLUS"
+                              "if": [
+                                {
+                                  "in": [
+                                    {
+                                      "var": "payload.t.0.tt"
+                                    },
+                                    [
+                                      "94504-8"
+                                    ]
+                                  ]
+                                },
+                                "SUCCESS_2G",
+                                "INVALID"
+                              ]
+                            }
                           ]
                         },
-                        "INVALID",
-                        "UNKNOWN_MODE"
+                        {
+                          "if": [
+                            {
+                              "===": [
+                                {
+                                  "var": "payload.h.mode"
+                                },
+                                "TWO_G_PLUS"
+                              ]
+                            },
+                            "INVALID",
+                            "UNKNOWN_MODE"
+                          ]
+                        }
                       ]
                     }
                   ]

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/mode-rules/modeRules.aifc
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/mode-rules/modeRules.aifc
@@ -22,9 +22,23 @@ switch(payload.h.mode){
         /*IS LIGHT*/
         "IS_LIGHT"
     }
-    "TWO_G_PLUS": if (payload.v.0 || payload.r.0) => {
-        /*First part of 2g plus*/
-        "SUCCESS_2G"
+    "TWO_G_PLUS": if (payload.v.0) => {
+        if((now() + 0#days) is not after (payload.v.0.dt as DateTime + 90#days)){
+            /* within 90 days, a test is not required */
+            "SUCCESS"
+        }else{
+            /*First part of 2g plus*/
+            "SUCCESS_2G"
+        }
+    }
+    "TWO_G_PLUS": if (payload.r.0) => {
+        if((now() + 0#days) is not after (payload.r.0.fr as DateTime + 90#days)){
+           /* within 90 days, a test is not required */
+           "SUCCESS"
+        }else{
+           /*First part of 2g plus*/
+           "SUCCESS_2G"
+        }
     }
     "TWO_G_PLUS": if (payload.t.0) => {
         switch(payload.t.0.tt){

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/verificationRulesV2.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/verificationRulesV2.json
@@ -1501,30 +1501,38 @@
                           ]
                         },
                         {
-                          "!": [
-                            {
-                              "and": [
-                                {
-                                  "!": [
-                                    {
-                                      "var": "payload.v.0"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "!": [
-                                    {
-                                      "var": "payload.r.0"
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
+                          "var": "payload.v.0"
                         }
                       ]
                     },
-                    "SUCCESS_2G",
+                    {
+                      "if": [
+                        {
+                          "not-after": [
+                            {
+                              "plusTime": [
+                                {
+                                  "var": "external.validationClock"
+                                },
+                                0,
+                                "day"
+                              ]
+                            },
+                            {
+                              "plusTime": [
+                                {
+                                  "var": "payload.v.0.dt"
+                                },
+                                90,
+                                "day"
+                              ]
+                            }
+                          ]
+                        },
+                        "SUCCESS",
+                        "SUCCESS_2G"
+                      ]
+                    },
                     {
                       "if": [
                         {
@@ -1538,24 +1546,55 @@
                               ]
                             },
                             {
-                              "var": "payload.t.0"
+                              "var": "payload.r.0"
                             }
                           ]
                         },
                         {
                           "if": [
                             {
-                              "in": [
+                              "not-after": [
                                 {
-                                  "var": "payload.t.0.tt"
+                                  "plusTime": [
+                                    {
+                                      "var": "external.validationClock"
+                                    },
+                                    0,
+                                    "day"
+                                  ]
                                 },
-                                [
-                                  "LP6464-4",
-                                  "LP217198-3"
-                                ]
+                                {
+                                  "plusTime": [
+                                    {
+                                      "var": "payload.r.0.fr"
+                                    },
+                                    90,
+                                    "day"
+                                  ]
+                                }
                               ]
                             },
-                            "SUCCESS_2G_PLUS",
+                            "SUCCESS",
+                            "SUCCESS_2G"
+                          ]
+                        },
+                        {
+                          "if": [
+                            {
+                              "and": [
+                                {
+                                  "===": [
+                                    {
+                                      "var": "payload.h.mode"
+                                    },
+                                    "TWO_G_PLUS"
+                                  ]
+                                },
+                                {
+                                  "var": "payload.t.0"
+                                }
+                              ]
+                            },
                             {
                               "if": [
                                 {
@@ -1564,28 +1603,44 @@
                                       "var": "payload.t.0.tt"
                                     },
                                     [
-                                      "94504-8"
+                                      "LP6464-4",
+                                      "LP217198-3"
                                     ]
                                   ]
                                 },
-                                "SUCCESS_2G",
-                                "INVALID"
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "if": [
-                            {
-                              "===": [
+                                "SUCCESS_2G_PLUS",
                                 {
-                                  "var": "payload.h.mode"
-                                },
-                                "TWO_G_PLUS"
+                                  "if": [
+                                    {
+                                      "in": [
+                                        {
+                                          "var": "payload.t.0.tt"
+                                        },
+                                        [
+                                          "94504-8"
+                                        ]
+                                      ]
+                                    },
+                                    "SUCCESS_2G",
+                                    "INVALID"
+                                  ]
+                                }
                               ]
                             },
-                            "INVALID",
-                            "UNKNOWN_MODE"
+                            {
+                              "if": [
+                                {
+                                  "===": [
+                                    {
+                                      "var": "payload.h.mode"
+                                    },
+                                    "TWO_G_PLUS"
+                                  ]
+                                },
+                                "INVALID",
+                                "UNKNOWN_MODE"
+                              ]
+                            }
                           ]
                         }
                       ]


### PR DESCRIPTION
Update to the 2G+ mode: Vaccine or recovery within the last 90 days gives a SUCCESS state (not SUCCESS_2G)﻿
