### PR TITLE
fix/test cert light

### DIFF
--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/generated/mode-rules/modeRules.aifc.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/generated/mode-rules/modeRules.aifc.json
@@ -233,34 +233,54 @@
                                       ]
                                     },
                                     {
-                                      "var": "payload.t.0"
-                                    },
-                                    {
-                                      "in": [
-                                        {
-                                          "var": "payload.t.0.tt"
-                                        },
-                                        [
-                                          "LP6464-4",
-                                          "LP217198-3"
-                                        ]
-                                      ]
+                                      "var": "payload.h.isLight"
                                     }
                                   ]
                                 },
-                                "SUCCESS",
+                                "IS_LIGHT",
                                 {
                                   "if": [
                                     {
-                                      "===": [
+                                      "and": [
                                         {
-                                          "var": "payload.h.mode"
+                                          "===": [
+                                            {
+                                              "var": "payload.h.mode"
+                                            },
+                                            "TEST_CERT"
+                                          ]
                                         },
-                                        "TEST_CERT"
+                                        {
+                                          "var": "payload.t.0"
+                                        },
+                                        {
+                                          "in": [
+                                            {
+                                              "var": "payload.t.0.tt"
+                                            },
+                                            [
+                                              "LP6464-4",
+                                              "LP217198-3"
+                                            ]
+                                          ]
+                                        }
                                       ]
                                     },
-                                    "INVALID",
-                                    "UNKNOWN_MODE"
+                                    "SUCCESS",
+                                    {
+                                      "if": [
+                                        {
+                                          "===": [
+                                            {
+                                              "var": "payload.h.mode"
+                                            },
+                                            "TEST_CERT"
+                                          ]
+                                        },
+                                        "INVALID",
+                                        "UNKNOWN_MODE"
+                                      ]
+                                    }
                                   ]
                                 }
                               ]

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/mode-rules/modeRules.aifc
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/mode-rules/modeRules.aifc
@@ -52,6 +52,10 @@ switch(payload.h.mode){
     "TWO_G_PLUS" => {
        "INVALID"
     }
+    "TEST_CERT": if (payload.h.isLight) => {
+            /*IS LIGHT*/
+            "IS_LIGHT"
+    }
     "TEST_CERT": if(payload.t.0 && payload.t.0.tt in ["LP6464-4", "LP217198-3"]) => {
             "SUCCESS"
     }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/verificationRulesV2.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/verificationRulesV2.json
@@ -1655,34 +1655,54 @@
                                           ]
                                         },
                                         {
-                                          "var": "payload.t.0"
-                                        },
-                                        {
-                                          "in": [
-                                            {
-                                              "var": "payload.t.0.tt"
-                                            },
-                                            [
-                                              "LP6464-4",
-                                              "LP217198-3"
-                                            ]
-                                          ]
+                                          "var": "payload.h.isLight"
                                         }
                                       ]
                                     },
-                                    "SUCCESS",
+                                    "IS_LIGHT",
                                     {
                                       "if": [
                                         {
-                                          "===": [
+                                          "and": [
                                             {
-                                              "var": "payload.h.mode"
+                                              "===": [
+                                                {
+                                                  "var": "payload.h.mode"
+                                                },
+                                                "TEST_CERT"
+                                              ]
                                             },
-                                            "TEST_CERT"
+                                            {
+                                              "var": "payload.t.0"
+                                            },
+                                            {
+                                              "in": [
+                                                {
+                                                  "var": "payload.t.0.tt"
+                                                },
+                                                [
+                                                  "LP6464-4",
+                                                  "LP217198-3"
+                                                ]
+                                              ]
+                                            }
                                           ]
                                         },
-                                        "INVALID",
-                                        "UNKNOWN_MODE"
+                                        "SUCCESS",
+                                        {
+                                          "if": [
+                                            {
+                                              "===": [
+                                                {
+                                                  "var": "payload.h.mode"
+                                                },
+                                                "TEST_CERT"
+                                              ]
+                                            },
+                                            "INVALID",
+                                            "UNKNOWN_MODE"
+                                          ]
+                                        }
                                       ]
                                     }
                                   ]


### PR DESCRIPTION
Fixes the handling of light certs in TEST_CERT verification mode. They were already rejected but not with the IS_LIGHT result
