### PR TITLE
Feature: Add COVOVAX to metadata valuesets

### DIFF
--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/valuesets/vaccine-medicinal-product.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/valuesets/vaccine-medicinal-product.json
@@ -183,6 +183,13 @@
       "active": true,
       "system": "https://ec.europa.eu/health/documents/community-register/html/",
       "version": ""
+    },
+    "COVOVAX": {
+      "display": "COVOVAX (Novavax formulation)",
+      "lang": "en",
+      "active": true,
+      "system": "http://ec.europa.eu/temp/vaccineproductname",
+      "version": ""
     }
   }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/EtagUtilTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/EtagUtilTest.java
@@ -50,7 +50,7 @@ public class EtagUtilTest {
 
     @Test
     public void testFileHashMultiple() throws Exception {
-        String expected = "W/\"7b1809a39c13a84a169a275213dd37407c0dc691\"";
+        String expected = "W/\"9321a8120e6050b7baf1cc317bedf4e87cbcb903\"";
         List<String> pathsToValueSets =
                 ValueSetsController.PATHS_TO_VALUE_SETS.stream()
                         .map(p -> "classpath:" + p)


### PR DESCRIPTION
This PR adds the WHO-listed COVOVAX (Serum Institute of India) as vaccine medicinal product to the value set (not yet available in the official value-set of EU/EHN) sucht that the vaccine is displayed with the correct name.

THIS ADDS NO VERIFICATION RULES!