### PR TITLE
test mode fix

### DIFF
--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/mode-rules/modeRules.aifc
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-valuesets/src/main/resources/mode-rules/modeRules.aifc
@@ -95,7 +95,7 @@ switch(payload.h.mode){
             "SUCCESS"
     }
     /* only negative RAT are treated like test certs */
-    "TEST_CERT": if(payload.t.0 && payload.t.0.tt in ["LP217198-3"] && payload.t.0.tr === "260373001") => {
+    "TEST_CERT": if(payload.t.0 && payload.t.0.tt in ["LP217198-3"] && payload.t.0.tr === "260415000") => {
          "SUCCESS"
     }
     "TEST_CERT" => {


### PR DESCRIPTION
This pull-request makes sure we only accept negative RAT tests in the dedicated "Test certificate" verifier mode.