### PR TITLE
load test manufacturers from db (valuesets)

### DIFF
--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/impl/JdbcCertUploadDataServiceImpl.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/impl/JdbcCertUploadDataServiceImpl.java
@@ -35,9 +35,7 @@ public class JdbcCertUploadDataServiceImpl implements CertUploadDataService {
     @Override
     public List<CertToUpload> findCertsToUpload() {
         return jt.query(
-                "select * from t_cert_to_upload"
-                        + " where inserted_at is null"
-                        + " or uploaded_at is null",
+                "select * from t_cert_to_upload where key_id is null",
                 new MapSqlParameterSource(),
                 new CertToUploadRowMapper());
     }
@@ -47,10 +45,12 @@ public class JdbcCertUploadDataServiceImpl implements CertUploadDataService {
         String sql =
                 "update t_cert_to_upload"
                         + " set inserted_at = :inserted_at,"
-                        + " uploaded_at = :uploaded_at"
+                        + " uploaded_at = :uploaded_at,"
+                        + " key_id = :key_id"
                         + " where pk_alias = :pk_alias";
         MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue("pk_alias", certToUpload.getAlias());
+        params.addValue("key_id", certToUpload.getKeyId());
         params.addValue("inserted_at", DateUtil.instantToDate(certToUpload.getInsertedAt()));
         params.addValue("uploaded_at", DateUtil.instantToDate(certToUpload.getUploadedAt()));
         jt.update(sql, params);

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/mapper/CertToUploadRowMapper.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/mapper/CertToUploadRowMapper.java
@@ -22,16 +22,22 @@ public class CertToUploadRowMapper implements RowMapper<CertToUpload> {
     public CertToUpload mapRow(ResultSet rs, int i) throws SQLException {
         CertToUpload certToUpload = new CertToUpload();
         certToUpload.setAlias(rs.getString("pk_alias"));
+        certToUpload.setKeyId(rs.getString("key_id"));
 
         Timestamp uploadedAt = rs.getTimestamp("uploaded_at");
         if (uploadedAt != null) {
             certToUpload.setUploadedAt(uploadedAt.toInstant());
         }
 
+        certToUpload.setDoUpload(rs.getBoolean("do_upload"));
+
         Timestamp insertedAt = rs.getTimestamp("inserted_at");
         if (insertedAt != null) {
             certToUpload.setInsertedAt(insertedAt.toInstant());
         }
+
+        certToUpload.setDoInsert(rs.getBoolean("do_insert"));
+
         return certToUpload;
     }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/resources/db/migration/pgsql/V0_11__cert_upload2.sql
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/resources/db/migration/pgsql/V0_11__cert_upload2.sql
@@ -1,0 +1,10 @@
+ALTER TABLE t_cert_to_upload ADD COLUMN key_id character varying(20);
+ALTER TABLE t_cert_to_upload ADD COLUMN do_upload boolean not null default false;
+ALTER TABLE t_cert_to_upload ADD COLUMN do_insert boolean not null default false;
+
+CREATE INDEX idx_cert_to_upload_key_id ON t_cert_to_upload (key_id);
+CREATE INDEX idx_cert_to_upload_do_upload ON t_cert_to_upload (do_upload);
+CREATE INDEX idx_cert_to_upload_do_insert ON t_cert_to_upload (do_insert);
+
+UPDATE t_cert_to_upload SET do_insert = true, do_upload = true;
+UPDATE t_cert_to_upload SET uploaded_at = null, do_upload = false where uploaded_at in ('2022-01-01 00:00:00+00', '2021-01-01 00:00:00+00');

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/resources/db/migration/pgsql_cluster/V0_11__cert_upload2.sql
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/resources/db/migration/pgsql_cluster/V0_11__cert_upload2.sql
@@ -1,0 +1,10 @@
+ALTER TABLE t_cert_to_upload ADD COLUMN key_id character varying(20);
+ALTER TABLE t_cert_to_upload ADD COLUMN do_upload boolean not null default false;
+ALTER TABLE t_cert_to_upload ADD COLUMN do_insert boolean not null default false;
+
+CREATE INDEX idx_cert_to_upload_key_id ON t_cert_to_upload (key_id);
+CREATE INDEX idx_cert_to_upload_do_upload ON t_cert_to_upload (do_upload);
+CREATE INDEX idx_cert_to_upload_do_insert ON t_cert_to_upload (do_insert);
+
+UPDATE t_cert_to_upload SET do_insert = true, do_upload = true;
+UPDATE t_cert_to_upload SET uploaded_at = null, do_upload = false where uploaded_at in ('2022-01-01 00:00:00+00', '2021-01-01 00:00:00+00');

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-model/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/model/cert/CertToUpload.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-model/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/model/cert/CertToUpload.java
@@ -14,8 +14,11 @@ import java.time.Instant;
 
 public class CertToUpload {
     private String alias;
+    private String keyId;
     private Instant uploadedAt;
+    private Boolean doUpload;
     private Instant insertedAt;
+    private Boolean doInsert;
 
     public String getAlias() {
         return alias;
@@ -23,6 +26,14 @@ public class CertToUpload {
 
     public void setAlias(String alias) {
         this.alias = alias;
+    }
+
+    public String getKeyId() {
+        return keyId;
+    }
+
+    public void setKeyId(String keyId) {
+        this.keyId = keyId;
     }
 
     public Instant getUploadedAt() {
@@ -37,6 +48,14 @@ public class CertToUpload {
         return this.uploadedAt != null;
     }
 
+    public Boolean doUpload() {
+        return doUpload;
+    }
+
+    public void setDoUpload(Boolean doUpload) {
+        this.doUpload = doUpload;
+    }
+
     public Instant getInsertedAt() {
         return insertedAt;
     }
@@ -47,5 +66,13 @@ public class CertToUpload {
 
     public boolean wasInserted() {
         return this.insertedAt != null;
+    }
+
+    public Boolean doInsert() {
+        return doInsert;
+    }
+
+    public void setDoInsert(Boolean doInsert) {
+        this.doInsert = doInsert;
     }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/WsBaseConfig.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/ws/config/WsBaseConfig.java
@@ -84,8 +84,8 @@ public abstract class WsBaseConfig implements WebMvcConfigurer {
     @Value("${testing.disabledModes:}")
     private String[] disabledVerificationModes;
 
-    //This is a safeguard so we can prevent the value from being read in the prod environment
-    protected String[] getDisabledVerificationModes(){
+    // This is a safeguard so we can prevent the value from being read in the prod environment
+    protected String[] getDisabledVerificationModes() {
         return disabledVerificationModes;
     }
 
@@ -170,7 +170,8 @@ public abstract class WsBaseConfig implements WebMvcConfigurer {
     public VerifierDataService verifierDataService(
             DataSource dataSource,
             @Value("${dsc.deleted.keep.duration:P7D}") Duration keepDscsMarkedForDeletionDuration) {
-        return new JdbcVerifierDataServiceImpl(dataSource, dscBatchSize, keepDscsMarkedForDeletionDuration);
+        return new JdbcVerifierDataServiceImpl(
+                dataSource, dscBatchSize, keepDscsMarkedForDeletionDuration);
     }
 
     @Bean
@@ -216,16 +217,17 @@ public abstract class WsBaseConfig implements WebMvcConfigurer {
         return new VerificationRulesController();
     }
 
-
     @Bean
     public VerificationRulesControllerV2 verificationRulesControllerV2(
             ValueSetDataService valueSetDataService) throws IOException, NoSuchAlgorithmException {
-        return new VerificationRulesControllerV2(valueSetDataService, getDisabledVerificationModes());
+        return new VerificationRulesControllerV2(
+                valueSetDataService, getDisabledVerificationModes());
     }
 
     @Bean
-    public ValueSetsController valueSetsController() throws IOException, NoSuchAlgorithmException {
-        return new ValueSetsController();
+    public ValueSetsController valueSetsController(ValueSetDataService valueSetDataService)
+            throws IOException {
+        return new ValueSetsController(valueSetDataService);
     }
 
     @Bean

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/EtagUtilTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/EtagUtilTest.java
@@ -13,12 +13,10 @@ package ch.admin.bag.covidcertificate.backend.verifier.ws;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import ch.admin.bag.covidcertificate.backend.verifier.ws.controller.ValueSetsController;
 import ch.admin.bag.covidcertificate.backend.verifier.ws.utils.EtagUtil;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 public class EtagUtilTest {
@@ -52,9 +50,12 @@ public class EtagUtilTest {
     public void testFileHashMultiple() throws Exception {
         String expected = "W/\"acd0754cf3ac8fcee8ddba62cd6fe01dda8f7f82\"";
         List<String> pathsToValueSets =
-                ValueSetsController.PATHS_TO_VALUE_SETS.stream()
-                        .map(p -> "classpath:" + p)
-                        .collect(Collectors.toList());
+                List.of(
+                        "classpath:valuesets/test-manf.json",
+                        "classpath:valuesets/test-type.json",
+                        "classpath:valuesets/vaccine-mah-manf.json",
+                        "classpath:valuesets/vaccine-medicinal-product.json",
+                        "classpath:valuesets/vaccine-prophylaxis.json");
         String sha1 =
                 EtagUtil.getSha1HashForFiles(
                         true, pathsToValueSets.toArray(new String[pathsToValueSets.size()]));

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/ValueSetsControllerJsonTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/ValueSetsControllerJsonTest.java
@@ -29,7 +29,8 @@ import org.springframework.test.context.ActiveProfiles;
 public class ValueSetsControllerJsonTest extends ValueSetsControllerTest {
 
     @BeforeAll
-    public void setup() {
+    public void setup() throws Exception {
         this.acceptMediaType = MediaType.APPLICATION_JSON;
+        super.setup();
     }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/ValueSetsControllerJwsTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/controller/ValueSetsControllerJwsTest.java
@@ -29,7 +29,8 @@ import org.springframework.test.context.ActiveProfiles;
 public class ValueSetsControllerJwsTest extends ValueSetsControllerTest {
 
     @BeforeAll
-    public void setup() {
+    public void setup() throws Exception {
         this.acceptMediaType = JwsMessageConverter.JWS_MEDIA_TYPE;
+        super.setup();
     }
 }

--- a/docker-compose/stack.yml
+++ b/docker-compose/stack.yml
@@ -4,7 +4,6 @@ services:
 
   covidcert_db:
     image: postgres:11
-    restart: always
     environment:
       POSTGRES_PASSWORD: covidcert
       POSTGRES_DB: covidcert


### PR DESCRIPTION
Test manufacturer valuesets are now served from the DB instead of from a static file (/metadata endpoint)