### PR TITLE
add do_upload, do_insert and key_id to t_cert_to_upload

### DIFF
--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/impl/JdbcCertUploadDataServiceImpl.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/impl/JdbcCertUploadDataServiceImpl.java
@@ -35,9 +35,7 @@ public class JdbcCertUploadDataServiceImpl implements CertUploadDataService {
     @Override
     public List<CertToUpload> findCertsToUpload() {
         return jt.query(
-                "select * from t_cert_to_upload"
-                        + " where inserted_at is null"
-                        + " or uploaded_at is null",
+                "select * from t_cert_to_upload where key_id is null",
                 new MapSqlParameterSource(),
                 new CertToUploadRowMapper());
     }
@@ -47,10 +45,12 @@ public class JdbcCertUploadDataServiceImpl implements CertUploadDataService {
         String sql =
                 "update t_cert_to_upload"
                         + " set inserted_at = :inserted_at,"
-                        + " uploaded_at = :uploaded_at"
+                        + " uploaded_at = :uploaded_at,"
+                        + " key_id = :key_id"
                         + " where pk_alias = :pk_alias";
         MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue("pk_alias", certToUpload.getAlias());
+        params.addValue("key_id", certToUpload.getKeyId());
         params.addValue("inserted_at", DateUtil.instantToDate(certToUpload.getInsertedAt()));
         params.addValue("uploaded_at", DateUtil.instantToDate(certToUpload.getUploadedAt()));
         jt.update(sql, params);

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/mapper/CertToUploadRowMapper.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/mapper/CertToUploadRowMapper.java
@@ -22,16 +22,22 @@ public class CertToUploadRowMapper implements RowMapper<CertToUpload> {
     public CertToUpload mapRow(ResultSet rs, int i) throws SQLException {
         CertToUpload certToUpload = new CertToUpload();
         certToUpload.setAlias(rs.getString("pk_alias"));
+        certToUpload.setKeyId(rs.getString("key_id"));
 
         Timestamp uploadedAt = rs.getTimestamp("uploaded_at");
         if (uploadedAt != null) {
             certToUpload.setUploadedAt(uploadedAt.toInstant());
         }
 
+        certToUpload.setDoUpload(rs.getBoolean("do_upload"));
+
         Timestamp insertedAt = rs.getTimestamp("inserted_at");
         if (insertedAt != null) {
             certToUpload.setInsertedAt(insertedAt.toInstant());
         }
+
+        certToUpload.setDoInsert(rs.getBoolean("do_insert"));
+
         return certToUpload;
     }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/resources/db/migration/pgsql/V0_11__cert_upload2.sql
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/resources/db/migration/pgsql/V0_11__cert_upload2.sql
@@ -1,0 +1,10 @@
+ALTER TABLE t_cert_to_upload ADD COLUMN key_id character varying(20);
+ALTER TABLE t_cert_to_upload ADD COLUMN do_upload boolean not null default false;
+ALTER TABLE t_cert_to_upload ADD COLUMN do_insert boolean not null default false;
+
+CREATE INDEX idx_cert_to_upload_key_id ON t_cert_to_upload (key_id);
+CREATE INDEX idx_cert_to_upload_do_upload ON t_cert_to_upload (do_upload);
+CREATE INDEX idx_cert_to_upload_do_insert ON t_cert_to_upload (do_insert);
+
+UPDATE t_cert_to_upload SET do_insert = true, do_upload = true;
+UPDATE t_cert_to_upload SET uploaded_at = null, do_upload = false where uploaded_at in ('2022-01-01 00:00:00+00', '2021-01-01 00:00:00+00');

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/resources/db/migration/pgsql_cluster/V0_11__cert_upload2.sql
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/resources/db/migration/pgsql_cluster/V0_11__cert_upload2.sql
@@ -1,0 +1,10 @@
+ALTER TABLE t_cert_to_upload ADD COLUMN key_id character varying(20);
+ALTER TABLE t_cert_to_upload ADD COLUMN do_upload boolean not null default false;
+ALTER TABLE t_cert_to_upload ADD COLUMN do_insert boolean not null default false;
+
+CREATE INDEX idx_cert_to_upload_key_id ON t_cert_to_upload (key_id);
+CREATE INDEX idx_cert_to_upload_do_upload ON t_cert_to_upload (do_upload);
+CREATE INDEX idx_cert_to_upload_do_insert ON t_cert_to_upload (do_insert);
+
+UPDATE t_cert_to_upload SET do_insert = true, do_upload = true;
+UPDATE t_cert_to_upload SET uploaded_at = null, do_upload = false where uploaded_at in ('2022-01-01 00:00:00+00', '2021-01-01 00:00:00+00');

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-model/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/model/cert/CertToUpload.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-model/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/model/cert/CertToUpload.java
@@ -14,8 +14,11 @@ import java.time.Instant;
 
 public class CertToUpload {
     private String alias;
+    private String keyId;
     private Instant uploadedAt;
+    private Boolean doUpload;
     private Instant insertedAt;
+    private Boolean doInsert;
 
     public String getAlias() {
         return alias;
@@ -23,6 +26,14 @@ public class CertToUpload {
 
     public void setAlias(String alias) {
         this.alias = alias;
+    }
+
+    public String getKeyId() {
+        return keyId;
+    }
+
+    public void setKeyId(String keyId) {
+        this.keyId = keyId;
     }
 
     public Instant getUploadedAt() {
@@ -37,6 +48,14 @@ public class CertToUpload {
         return this.uploadedAt != null;
     }
 
+    public Boolean doUpload() {
+        return doUpload;
+    }
+
+    public void setDoUpload(Boolean doUpload) {
+        this.doUpload = doUpload;
+    }
+
     public Instant getInsertedAt() {
         return insertedAt;
     }
@@ -47,5 +66,13 @@ public class CertToUpload {
 
     public boolean wasInserted() {
         return this.insertedAt != null;
+    }
+
+    public Boolean doInsert() {
+        return doInsert;
+    }
+
+    public void setDoInsert(Boolean doInsert) {
+        this.doInsert = doInsert;
     }
 }


### PR DESCRIPTION
this pull request improves the dsc upload mechanism. if a dsc is to be uploaded or inserted is now not explicitly defined by two booleans in the db table. furthermore the keyId is also stored in the database, so the `t_cert_to_upload` entry can easily be matched to the inserted row in the `t_document_signer_certificate` table