### PR TITLE
Update vaccine valuesets to version 1.9

### DIFF
--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/valuesets/vaccine-mah-manf.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/valuesets/vaccine-mah-manf.json
@@ -169,6 +169,41 @@
       "active": true,
       "system": "https://spor.ema.europa.eu/v1/organisations",
       "version": ""
+    },
+    "Instituto-Butantan": {
+      "display": "Instituto Butantan",
+      "lang": "en",
+      "active": true,
+      "system": "http://ec.europa.eu/temp/vaccinemanufacturer",
+      "version": "1.9"
+    },
+    "NVSI": {
+      "display": "National Vaccine and Serum Institute, China",
+      "lang": "en",
+      "active": true,
+      "system": "http://ec.europa.eu/temp/vaccinemanufacturer",
+      "version": "1.9"
+    },
+    "Yisheng-Biopharma": {
+      "display": "Yisheng Biopharma",
+      "lang": "en",
+      "active": true,
+      "system": "http://ec.europa.eu/temp/vaccinemanufacturer",
+      "version": "1.9"
+    },
+    "ORG-100026614": {
+      "display": "Sinocelltech Ltd.",
+      "lang": "en",
+      "active": true,
+      "system": "https://spor.ema.europa.eu/v1/organisations",
+      "version": ""
+    },
+    "ORG-100008549": {
+      "display": "Medicago Inc.",
+      "lang": "en",
+      "active": true,
+      "system": "https://spor.ema.europa.eu/v1/organisations",
+      "version": ""
     }
   }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/valuesets/vaccine-medicinal-product.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/valuesets/vaccine-medicinal-product.json
@@ -101,21 +101,21 @@
       "version": "1.0"
     },
     "Covaxin": {
-      "display": "Covaxin (also known as BBV152 A, B, C)",
+      "display": "Covaxin",
       "lang": "en",
       "active": true,
       "system": "http://ec.europa.eu/temp/vaccineproductname",
       "version": "1.0"
     },
     "Covaxin_T": {
-      "display": "Covaxin (also known as BBV152 A, B, C)",
+      "display": "Covaxin",
       "lang": "en",
       "active": true,
       "system": "http://ec.europa.eu/temp/vaccineproductname",
       "version": "1.0"
     },
     "Covishield": {
-      "display": "Covishield (ChAdOx1_nCoV-19)",
+      "display": "Covishield",
       "lang": "en",
       "active": true,
       "system": "http://ec.europa.eu/temp/vaccineproductname",
@@ -225,6 +225,48 @@
       "active": true,
       "system": "http://ec.europa.eu/temp/vaccineproductname",
       "version": "1.8"
+    },
+    "Covid-19-adsorvida-inativada": {
+      "display": "Vacina adsorvida covid-19 (inativada)",
+      "lang": "en",
+      "active": true,
+      "system": "http://ec.europa.eu/temp/vaccineproductname",
+      "version": "1.9"
+    },
+    "NVSI-06-08": {
+      "display": "NVSI-06-08",
+      "lang": "en",
+      "active": true,
+      "system": "http://ec.europa.eu/temp/vaccineproductname",
+      "version": "1.9"
+    },
+    "YS-SC2-010": {
+      "display": "YS-SC2-010",
+      "lang": "en",
+      "active": true,
+      "system": "http://ec.europa.eu/temp/vaccineproductname",
+      "version": "1.9"
+    },
+    "SCTV01C": {
+      "display": "SCTV01C",
+      "lang": "en",
+      "active": true,
+      "system": "http://ec.europa.eu/temp/vaccineproductname",
+      "version": "1.9"
+    },
+    "Covifenz": {
+      "display": "Covifenz",
+      "lang": "en",
+      "active": true,
+      "system": "http://ec.europa.eu/temp/vaccineproductname",
+      "version": "1.9"
+    },
+    "AZD2816": {
+      "display": "AZD2816",
+      "lang": "en",
+      "active": true,
+      "system": "http://ec.europa.eu/temp/vaccineproductname",
+      "version": "1.9"
     }
   }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/valuesets/vaccine-prophylaxis.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/valuesets/vaccine-prophylaxis.json
@@ -22,6 +22,27 @@
       "active": true,
       "version": "2021-01",
       "system": "http://www.whocc.no/atc"
+    },
+    "1162643001": {
+      "display": "SARS-CoV-2 recombinant spike protein antigen vaccine",
+      "lang": "en",
+      "active": true,
+      "version": "2022-01-31",
+      "system": "http://snomed.info/sct"
+    },
+    "1157024006": {
+      "display": "Inactivated whole SARS-CoV-2 antigen vaccine",
+      "lang": "en",
+      "active": true,
+      "version": "2022-01-31",
+      "system": "http://snomed.info/sct"
+    },
+    "29061000087103": {
+      "display": "COVID-19 non-replicating viral vector vaccine",
+      "lang": "en",
+      "active": true,
+      "version": "2022-01-31",
+      "system": "http://snomed.info/sct"
     }
   }
 }

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/EtagUtilTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/EtagUtilTest.java
@@ -48,7 +48,7 @@ public class EtagUtilTest {
 
     @Test
     public void testFileHashMultiple() throws Exception {
-        String expected = "W/\"acd0754cf3ac8fcee8ddba62cd6fe01dda8f7f82\"";
+        String expected = "W/\"8fd5d9f8c88f12eaf34309358f925604cced3d7d\"";
         List<String> pathsToValueSets =
                 List.of(
                         "classpath:valuesets/test-manf.json",


### PR DESCRIPTION
This pull-request updated the value-set to [version 1.9 ](https://ec.europa.eu/health/system/files/2022-03/eu-dcc-value-sets_en.pdf)
