### PR TITLE
improve cert to upload select query

### DIFF
--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/impl/JdbcCertUploadDataServiceImpl.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-data/src/main/java/ch/admin/bag/covidcertificate/backend/verifier/data/impl/JdbcCertUploadDataServiceImpl.java
@@ -35,7 +35,10 @@ public class JdbcCertUploadDataServiceImpl implements CertUploadDataService {
     @Override
     public List<CertToUpload> findCertsToUpload() {
         return jt.query(
-                "select * from t_cert_to_upload where key_id is null",
+                "select * from t_cert_to_upload"
+                        + " where key_id is null"
+                        + " or (do_upload is true and uploaded_at is null)"
+                        + " or (do_insert is true and inserted_at is null)",
                 new MapSqlParameterSource(),
                 new CertToUploadRowMapper());
     }


### PR DESCRIPTION
This pull request improves the query, which selects certs to upload. Previously it was only checked if the `key_id` was not yet set. In order to enable (further) uploads or inserts at a later time, the query now also checks if the cert was marked to be inserted or uploaded, but hasn't been yet (empty timestamp)