### PR TITLE
Overwrite Janssen name

### DIFF
--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/valuesets/vaccine-medicinal-product.json
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/main/resources/valuesets/vaccine-medicinal-product.json
@@ -24,7 +24,7 @@
       "version": ""
     },
     "EU/1/20/1525": {
-      "display": "Jcovden",
+      "display": "Jcovden (previously COVID-19 Vaccine Janssen)",
       "lang": "en",
       "active": true,
       "system": "https://ec.europa.eu/health/documents/community-register/html/",

--- a/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/EtagUtilTest.java
+++ b/ch-covidcertificate-backend-verifier/ch-covidcertificate-backend-verifier-ws/src/test/java/ch/admin/bag/covidcertificate/backend/verifier/ws/EtagUtilTest.java
@@ -48,7 +48,7 @@ public class EtagUtilTest {
 
     @Test
     public void testFileHashMultiple() throws Exception {
-        String expected = "W/\"142370e8da04d0b6804b6952634d7ed079ec7dfe\"";
+        String expected = "W/\"94261230f884b347f2edc72de643ef8e5be383bc\"";
         List<String> pathsToValueSets =
                 List.of(
                         "classpath:valuesets/test-manf.json",


### PR DESCRIPTION
This PR overwrites the name of the Janssen vaccine to reflect the recent name change.